### PR TITLE
Add Array#element_counts

### DIFF
--- a/lib/more_core_extensions/core_ext/array.rb
+++ b/lib/more_core_extensions/core_ext/array.rb
@@ -1,5 +1,6 @@
 require 'more_core_extensions/core_ext/array/deletes'
 require 'more_core_extensions/core_ext/array/duplicates'
+require 'more_core_extensions/core_ext/array/element_counts'
 require 'more_core_extensions/core_ext/array/inclusions'
 require 'more_core_extensions/core_ext/array/nested'
 require 'more_core_extensions/core_ext/array/random'

--- a/lib/more_core_extensions/core_ext/array/duplicates.rb
+++ b/lib/more_core_extensions/core_ext/array/duplicates.rb
@@ -1,3 +1,5 @@
+require 'more_core_extensions/core_ext/array/element_counts'
+
 module MoreCoreExtensions
   module ArrayDuplicates
     #
@@ -5,7 +7,7 @@ module MoreCoreExtensions
     #
     #   [1, 2, 3, 4, 2, 4].duplicates  #=> [2, 4]
     def duplicates
-      self.inject(Hash.new(0)) { |h, v| h[v] += 1; h }.reject { |k, v| v == 1 }.keys
+      element_counts.reject { |k, v| v == 1 }.keys
     end
   end
 end

--- a/lib/more_core_extensions/core_ext/array/element_counts.rb
+++ b/lib/more_core_extensions/core_ext/array/element_counts.rb
@@ -1,0 +1,12 @@
+module MoreCoreExtensions
+  module ArrayElementCounts
+    # Returns a Hash of each element to the count of those elements.
+    #
+    #   [1, 2, 3, 1, 3, 1].counts  # => {1 => 3, 2 => 1, 3 => 2}
+    def element_counts
+      each_with_object(Hash.new(0)) { |i, h| h[i] += 1 }
+    end
+  end
+end
+
+Array.send(:include, MoreCoreExtensions::ArrayElementCounts)

--- a/spec/core_ext/array/element_counts_spec.rb
+++ b/spec/core_ext/array/element_counts_spec.rb
@@ -1,0 +1,10 @@
+require "spec_helper"
+
+describe Array do
+  it "#element_counts" do
+    [].element_counts.should == {}
+    [1].element_counts.should == {1 => 1}
+    [nil].element_counts.should == {nil => 1}
+    [1, 2, 3, 1, 3, 1].element_counts.should == {1 => 3, 2 => 1, 3 => 2}
+  end
+end


### PR DESCRIPTION
Change Array#duplicates to leverage #element_counts

@brandondunne / @jrafanie Please review.  This came out of discussion in https://github.com/ManageIQ/cfme/pull/1576#discussion_r8939083 and I realized we sort of already do this in the Array#duplicates method.  I'm also not sure on the method name itself.  Thoughts?
