### PR TITLE
Require active_support before core_ext to fix uninitialized constant.

### DIFF
--- a/lib/more_core_extensions/core_ext/array/deletes.rb
+++ b/lib/more_core_extensions/core_ext/array/deletes.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/object/blank'
 
 module MoreCoreExtensions

--- a/lib/more_core_extensions/core_ext/hash/deletes.rb
+++ b/lib/more_core_extensions/core_ext/hash/deletes.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext/object/blank'
 
 module MoreCoreExtensions

--- a/spec/core_ext/hash/nested_spec.rb
+++ b/spec/core_ext/hash/nested_spec.rb
@@ -192,6 +192,7 @@ describe Hash do
   include_examples "core_ext/hash/nested"
 end
 
+require 'active_support'
 require 'active_support/core_ext/hash'
 describe HashWithIndifferentAccess do
   let(:hash) do


### PR DESCRIPTION
This is a known issue with activesupport and travis:
https://github.com/rails/rails/issues/14664

See also:
https://github.com/ManageIQ/polisher/commit/c899d500502a57582a906dfa20cc6cf343c09265
https://github.com/ManageIQ/linux_admin/pull/103
