### PR TITLE
Array#include_any? and friends now accept a single argument Array.

### DIFF
--- a/lib/more_core_extensions/core_ext/array/inclusions.rb
+++ b/lib/more_core_extensions/core_ext/array/inclusions.rb
@@ -7,6 +7,7 @@ module MoreCoreExtensions
     #   [1, 2, 3].include_any?(1, 4)  #=> true
     #   [1, 2, 3].include_any?(4, 5)  #=> false
     def include_any?(*items)
+      items = items.first if items.length == 1 && items.first.kind_of?(Array)
       !(self & items).empty?
     end
 
@@ -17,6 +18,7 @@ module MoreCoreExtensions
     #   [1, 2, 3].include_none?(1, 4)  #=> false
     #   [1, 2, 3].include_none?(4, 5)  #=> true
     def include_none?(*items)
+      items = items.first if items.length == 1 && items.first.kind_of?(Array)
       (self & items).empty?
     end
 
@@ -27,6 +29,7 @@ module MoreCoreExtensions
     #   [1, 2, 3].include_all?(1, 4)  #=> false
     #   [1, 2, 3].include_all?(4, 5)  #=> false
     def include_all?(*items)
+      items = items.first if items.length == 1 && items.first.kind_of?(Array)
       (items - self).empty?
     end
 

--- a/spec/core_ext/array/inclusions_spec.rb
+++ b/spec/core_ext/array/inclusions_spec.rb
@@ -3,30 +3,42 @@ describe Array do
     expect([1, 2, 3].include_any?(1, 2)).to be_truthy
     expect([1, 2, 3].include_any?(1, 4)).to be_truthy
     expect([1, 2, 3].include_any?(4, 5)).to be_falsey
+    expect([1, 2, 3].include_any?([1, 4])).to be_truthy
+    expect([1, 2, 3].include_any?([4, 5])).to be_falsey
 
     expect(['1', '2', '3'].include_any?('1', '2')).to be_truthy
     expect(['1', '2', '3'].include_any?('1', '4')).to be_truthy
     expect(['1', '2', '3'].include_any?('4', '5')).to be_falsey
+    expect(['1', '2', '3'].include_any?(['1', '4'])).to be_truthy
+    expect(['1', '2', '3'].include_any?(['4', '5'])).to be_falsey
   end
 
   it '#include_none?' do
     expect([1, 2, 3].include_none?(1, 2)).to be_falsey
     expect([1, 2, 3].include_none?(1, 4)).to be_falsey
     expect([1, 2, 3].include_none?(4, 5)).to be_truthy
+    expect([1, 2, 3].include_none?([1, 4])).to be_falsey
+    expect([1, 2, 3].include_none?([4, 5])).to be_truthy
 
     expect(['1', '2', '3'].include_none?('1', '2')).to be_falsey
     expect(['1', '2', '3'].include_none?('1', '4')).to be_falsey
     expect(['1', '2', '3'].include_none?('4', '5')).to be_truthy
+    expect(['1', '2', '3'].include_none?(['1', '4'])).to be_falsey
+    expect(['1', '2', '3'].include_none?(['4', '5'])).to be_truthy
   end
 
   it '#include_all?' do
     expect([1, 2, 3].include_all?(1, 2)).to be_truthy
     expect([1, 2, 3].include_all?(1, 4)).to be_falsey
     expect([1, 2, 3].include_all?(4, 5)).to be_falsey
+    expect([1, 2, 3].include_all?([1, 2])).to be_truthy
+    expect([1, 2, 3].include_all?([1, 4])).to be_falsey
 
     expect(['1', '2', '3'].include_all?('1', '2')).to be_truthy
     expect(['1', '2', '3'].include_all?('1', '4')).to be_falsey
     expect(['1', '2', '3'].include_all?('4', '5')).to be_falsey
+    expect(['1', '2', '3'].include_all?(['1', '2'])).to be_truthy
+    expect(['1', '2', '3'].include_all?(['1', '4'])).to be_falsey
   end
 
   it "#includes_index?" do


### PR DESCRIPTION
Fixes:
`[1, 2, 3].include_any?([1, 4])` returning false
It should behave the same as `[1, 2, 3].include_any?(1, 4)`

Single argument Arrays are splat so [1, 4] becomes [[1, 4]].  We have to
grab the first item of the multidimensional array if it's a single subarray.