### PR TITLE
Add ability to pass a transformation block to element_counts

### DIFF
--- a/lib/more_core_extensions/core_ext/array/element_counts.rb
+++ b/lib/more_core_extensions/core_ext/array/element_counts.rb
@@ -1,10 +1,16 @@
 module MoreCoreExtensions
   module ArrayElementCounts
-    # Returns a Hash of each element to the count of those elements.
+    # Returns a Hash of each element to the count of those elements.  Optionally
+    #  pass a block to count by a different criteria.
     #
     #   [1, 2, 3, 1, 3, 1].counts  # => {1 => 3, 2 => 1, 3 => 2}
+    #   %w(a aa aaa a aaa a).counts { |i| i.length }  # => {1 => 3, 2 => 1, 3 => 2}
+    #
     def element_counts
-      each_with_object(Hash.new(0)) { |i, h| h[i] += 1 }
+      each_with_object(Hash.new(0)) do |i, h|
+        key = block_given? ? yield(i) : i
+        h[key] += 1
+      end
     end
   end
 end

--- a/spec/core_ext/array/element_counts_spec.rb
+++ b/spec/core_ext/array/element_counts_spec.rb
@@ -1,8 +1,16 @@
 describe Array do
-  it "#element_counts" do
-    expect([].element_counts).to eq({})
-    expect([1].element_counts).to eq({1 => 1})
-    expect([nil].element_counts).to eq({nil => 1})
-    expect([1, 2, 3, 1, 3, 1].element_counts).to eq({1 => 3, 2 => 1, 3 => 2})
+  describe "#element_counts" do
+    it "without a block" do
+      expect([].element_counts).to eq({})
+      expect([1].element_counts).to eq({1 => 1})
+      expect([nil].element_counts).to eq({nil => 1})
+      expect([1, 2, 3, 1, 3, 1].element_counts).to eq({1 => 3, 2 => 1, 3 => 2})
+    end
+
+    it "with a block" do
+      expect([].element_counts(&:size)).to eq({})
+      expect(%w(a).element_counts(&:size)).to eq({1 => 1})
+      expect(%w(a aa aaa a aaa a).element_counts(&:size)).to eq({1 => 3, 2 => 1, 3 => 2})
+    end
   end
 end


### PR DESCRIPTION
@bdunne Please review.  I found I needed this for the memory_analyzer.  Makes counting objects by arbitrary properties a lot easier.