### PR TITLE
Array math fixes for small arrays

### DIFF
--- a/lib/more_core_extensions/core_ext/array/math.rb
+++ b/lib/more_core_extensions/core_ext/array/math.rb
@@ -8,6 +8,7 @@ module MoreCoreExtensions
     #   [1, 2, 3, 4, 5].mean  #=> 3.0
     #   [1.0, 2.0, 3.0].mean  #=> 2.0
     def mean
+      return 0.0 if empty?
       sum.to_f / length
     end
 

--- a/lib/more_core_extensions/core_ext/array/math.rb
+++ b/lib/more_core_extensions/core_ext/array/math.rb
@@ -27,6 +27,8 @@ module MoreCoreExtensions
     #   [1, 2, 3, 4, 5].variance  #=> 2.5
     #   [1.0, 2.0, 3.0].variance  #=> 1.0
     def variance
+      divisor = length - 1
+      return 0.0 unless divisor > 0
       μ = mean
       reduce(0) { |m, i| m + (i - μ).square } / (length - 1)
     end

--- a/spec/core_ext/array/math_spec.rb
+++ b/spec/core_ext/array/math_spec.rb
@@ -13,4 +13,17 @@ describe Array do
     it("#mean")     { expect(integers.mean).to     be_within(0.00001).of(3.00000) }
     it("#variance") { expect(integers.variance).to be_within(0.00001).of(2.50000) }
   end
+
+  context "with a single item" do
+    let(:single_item) { [5] }
+    it("#stddev")   { expect(single_item.stddev).to   eq(0.0) }
+    it("#mean")     { expect(single_item.mean).to     eq(5.0) }
+    it("#variance") { expect(single_item.variance).to eq(0.0) }
+  end
+
+  context "empty array" do
+    it("#stddev")   { expect([].stddev).to   eq(0.0) }
+    it("#mean")     { expect([].mean).to     eq(0.0) }
+    it("#variance") { expect([].variance).to eq(0.0) }
+  end
 end


### PR DESCRIPTION
`[].mean` should be 0.0
`[1].variance` should be 0.0