### PR TITLE
Move activesupport hack to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in more_core_extensions.gemspec
 gemspec
+
+# HACK: Rails 5 dropped support for Ruby < 2.2.2
+active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
+gem 'activesupport', active_support_version

--- a/more_core_extensions.gemspec
+++ b/more_core_extensions.gemspec
@@ -27,7 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0"
 
-  # HACK: Rails 5 dropped support for Ruby < 2.2.2
-  active_support_version = "< 5" if Gem::Version.new(RUBY_VERSION) <= Gem::Version.new("2.2.2")
-  spec.add_runtime_dependency "activesupport", active_support_version
+  spec.add_runtime_dependency "activesupport"
 end


### PR DESCRIPTION
Prevents limitation from showing up in the gemspec
Provides the proper requirement based on the ruby version in use