### PR TITLE
Allow for > 6 chars TLDs in email addresses

### DIFF
--- a/lib/more_core_extensions/core_ext/string/formats.rb
+++ b/lib/more_core_extensions/core_ext/string/formats.rb
@@ -1,7 +1,8 @@
 module MoreCoreExtensions
   module StringFormats
     # From: Regular Expression Cookbook: 4.1 Validate Email Addresses
-    RE_EMAIL = %r{\A[\w!#$\%&'*+/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,6}\Z}i
+    RE_EMAIL = %r{\A[\w!#$\%&'*+/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,}\Z}i
+
     def email?
       !!(self =~ RE_EMAIL)
     end

--- a/spec/core_ext/string/formats_spec.rb
+++ b/spec/core_ext/string/formats_spec.rb
@@ -2,6 +2,7 @@ describe String do
   it '#email?' do
     expect("john@example.com").to be_email
     expect("john.doe@example.com").to be_email
+    expect("john.doe@my-company.prestidigitation").to be_email
 
     expect("john.doe@examplecom").not_to be_email
     expect("john.doe@example-com").not_to be_email


### PR DESCRIPTION
As per RFC 1035

Addresses https://github.com/ManageIQ/manageiq/issues/12781

Thanks @Fryguy for the suggestion on this one. In the above issue you mentioned that we could also go further and use the regex outlined in http://www.regular-expressions.info/email.html. I do think that's a good idea and would like to do that, but am thinking I might do that in a follow up PR as it breaks some existing tests. I don't *think* that's a problem, but I'm being extra cautious - it should at least be easier to revert if it breaks anyone's workflow and keep this enhancement.

Also, TIL a new word: prestidigitation :grin: 

@miq-bot add-label enhacement
@miq-bot assign @Fryguy 