### PR TITLE
Update email regex

### DIFF
--- a/lib/more_core_extensions/core_ext/string/formats.rb
+++ b/lib/more_core_extensions/core_ext/string/formats.rb
@@ -1,7 +1,7 @@
 module MoreCoreExtensions
   module StringFormats
-    # From: Regular Expression Cookbook: 4.1 Validate Email Addresses
-    RE_EMAIL = %r{\A[\w!#$\%&'*+/=?`\{|\}~^-]+(?:\.[\w!#$\%&'*+/=?`\{|\}~^-]+)*@(?:[A-Z0-9-]+\.)+[A-Z]{2,}\Z}i
+    # From: http://www.regular-expressions.info/email.html
+    RE_EMAIL =  %r{\A[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z}
 
     def email?
       !!(self =~ RE_EMAIL)

--- a/spec/core_ext/string/formats_spec.rb
+++ b/spec/core_ext/string/formats_spec.rb
@@ -5,10 +5,7 @@ describe String do
     expect("john.doe@my-company.prestidigitation").to be_email
     expect("john.o'doe@example.com").to be_email
 
-    expect("john,doe@example.com").not_to be_email
     expect("john\ndoe@example.com").not_to be_email
-    expect("john.doe@examplecom").not_to be_email
-    expect("john.doe@example-com").not_to be_email
     expect("").not_to be_email
     expect("foo").not_to be_email
   end


### PR DESCRIPTION
Updates the email regex to use that defined in
http://www.regular-expressions.info/email.html. The main reason to do
this is because it is more permissive, and email regexes in general tend
to be overly constrictive. Sure enough, this breaks some of the existing
tests which asserted that certain combinations of characters were
invalid. Importantly, though, no assertions on valid emails were
broken (though the tests here aren't exhaustive, so pinch of salt).

Follow up to https://github.com/ManageIQ/manageiq/issues/12781

@Fryguy (assuming this is OK) do we need a version bump before and after this?