### PR TITLE
Allow mixed case in emails

### DIFF
--- a/lib/more_core_extensions/core_ext/string/formats.rb
+++ b/lib/more_core_extensions/core_ext/string/formats.rb
@@ -1,7 +1,7 @@
 module MoreCoreExtensions
   module StringFormats
     # From: http://www.regular-expressions.info/email.html
-    RE_EMAIL =  %r{\A[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z}
+    RE_EMAIL =  %r{\A[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z}i
 
     def email?
       !!(self =~ RE_EMAIL)

--- a/spec/core_ext/string/formats_spec.rb
+++ b/spec/core_ext/string/formats_spec.rb
@@ -4,6 +4,8 @@ describe String do
     expect("john.doe@example.com").to be_email
     expect("john.doe@my-company.prestidigitation").to be_email
     expect("john.o'doe@example.com").to be_email
+    expect("john.doe@EXAMPLE.COM").to be_email
+    expect("John.Doe@example.com").to be_email
 
     expect("john\ndoe@example.com").not_to be_email
     expect("").not_to be_email


### PR DESCRIPTION
Related to comments in https://github.com/ManageIQ/manageiq/pull/13586.

This was one of those cases where I wasn't sure whether to add a comment to indicate that the regex has deviated from the source we've referenced....But I think the commit message should be sufficient.

@miq-bot add-label bug
@miq-bot assign @Fryguy 