### PR TITLE
Reduce memory usage of `.store_path`

### DIFF
--- a/lib/more_core_extensions/core_ext/shared/nested.rb
+++ b/lib/more_core_extensions/core_ext/shared/nested.rb
@@ -62,21 +62,25 @@ module MoreCoreExtensions
       def store_path(*args)
         raise ArgumentError, "must pass at least one key, and a value" if args.length < 2
         value = args.pop
-        args = args.first if args.length == 1 && args.first.kind_of?(Array)
+        child = self
+        key   = args.first
 
-        key = args.first
-        raise ArgumentError, "must be a number" if self.kind_of?(Array) && !key.kind_of?(Numeric)
+        if args.length > 1 || args.first.kind_of?(Array)
+          keys = args.first.kind_of?(Array) ? args.first : args
+          keys.each_with_index do |cur_key, i|
+            raise ArgumentError, "must be a number" if child.kind_of?(Array) && !cur_key.kind_of?(Numeric)
+            key = cur_key # keep track of this for value assignment later
+            break if i + 1 == keys.size
 
-        if args.length == 1
-          self[key] = value
-        else
-          child = self[key]
-          unless child.respond_to?(:store_path)
-            self[key] = self.class.new
-            child = self[key]
+            unless child[cur_key].respond_to?(:store_path)
+              child[cur_key] = child.class.new
+            end
+
+            child = child[cur_key]
           end
-          child.store_path(args[1..-1].push, value)
         end
+
+        child[key] = value
       end
 
       #


### PR DESCRIPTION
Background
----------

By using recursion to loop through the keys for store path, we are creating new objects that are not needed (for the end result of the method) every time with go further down into the stack, because we are required to do a `args[1..-1].push` for each recursive call, which will create a new array from the subset of the args, and pass it into the next call of `.store_path`.

By not using recursion, we can completely remove any object allocations that aren't necessary (besides the ones that are needed for the method's spec), and still maintain the same functionality.  The added benefit is that this also now not prone to `stack level too deep` errors because it no longer requires recursion to function.


Benchmarks
----------

Using the changes from https://github.com/ManageIQ/manageiq/pull/15757, and some of the data found after the introduction of @chrisarcand 's PR, https://github.com/ManageIQ/manageiq/pull/15710 , which uses `store_path` as part of changes that weren't present prior, we can significantly reduce the number of objects allocated in that introduced because of that change (and probably reduce other cases where `.store_path` is used in the application as well:

```
before more_core_extensions patch                    after more_core_extensions patch

Total allocated: 68871116 bytes (854336 objects)   | Total allocated: 64535996 bytes (745958 objects)
Total retained:  5688721 bytes (48886 objects)     | Total retained:  5688721 bytes (48886 objects)
                                                   | 
allocated memory by gem                            | allocated memory by gem
-----------------------------------                | -----------------------------------
  17478431  activerecord-5.0.5                     |   17478431  activerecord-5.0.5
  16545419  activesupport-5.0.5                    |   16639019  activesupport-5.0.5
   8340370  more_core_extensions-3.3.0  <<<<<<     |    7629944  ruby-2.3.3/lib
   7629944  ruby-2.3.3/lib                         |    5779348  manageiq-providers-vmware-b45ffbbaefb3
   5779348  manageiq-providers-vmware-b45ffbbaefb3 |    4159069  manageiq/app
   4159069  manageiq/app                           |    3911650  more_core_extensions/lib  <<<<<<
   2428360  activemodel-5.0.5                      |    2428360  activemodel-5.0.5
   2221043  manageiq/lib                           |    2221043  manageiq/lib
   1894087  pending                                |    1894087  pending
   1557828  arel-7.1.4                             |    1557828  arel-7.1.4
    447304  american_date-1.1.1                    |     447304  american_date-1.1.1
    282320  other                                  |     282320  other
     73241  fast_gettext-1.2.0                     |      73241  fast_gettext-1.2.0
     34040  tzinfo-1.2.3                           |      34040  tzinfo-1.2.3
       272  default_value_for-3.0.2                |        272  default_value_for-3.0.2
        40  config-1.3.0                           |         40  config-1.3.0
```

`.fetch_path` has a similar issue (I might address that in another PR), which is why there is still a decent amount still being used by it, but this significantly reduces what was being allocated by the gem overall (in this benchmark).


Links
-----
* Where the issue was noticed:  https://github.com/ManageIQ/manageiq/pull/15757
* Change that cause this to be noticable:  https://github.com/ManageIQ/manageiq/pull/15710