### PR TITLE
Reduce memory usage of `.fetch_path`

### DIFF
--- a/lib/more_core_extensions/core_ext/shared/nested.rb
+++ b/lib/more_core_extensions/core_ext/shared/nested.rb
@@ -26,13 +26,17 @@ module MoreCoreExtensions
         args = args.first if args.length == 1 && args.first.kind_of?(Array)
         raise ArgumentError, "must pass at least one key" if args.empty?
 
-        key = args.first
-        raise ArgumentError, "must be a number" if self.kind_of?(Array) && !key.kind_of?(Numeric)
+        result = self
+        args.each_with_index do |key, i|
+          raise ArgumentError, "must be a number" if result.kind_of?(Array) && !key.kind_of?(Numeric)
 
-        child = self[key]
-        return child if args.length == 1
-        return nil unless child.respond_to?(:fetch_path)
-        return child.fetch_path(args[1..-1])
+          result = result[key]
+          if !result.respond_to?(:fetch_path) && (i + 1) != args.size
+            result = nil
+            break
+          end
+        end
+        result
       end
 
       #


### PR DESCRIPTION
Similar rational to https://github.com/ManageIQ/more_core_extensions/pull/54


A note about the implementation
-------------------------------

Of note, I attempted to use both `.each_with_object` and `.inject` instead of implementing something myself.  But each had it's own problems that were either broken or sub-optimal:

### `.each_with_object`

The `.each_with_object` implementation looked something like this:

```
args.each.with_index.each_with_object(self) do |(key, i), result|
```

Obviously this allows us to omit the `result = self` line above it, but this implementation just failed to function in some scenarios and I was unable to determine the cause.


### `.inject`

The `.inject` implementation was similar to the above `.each_with_object` implementation:

```
args.each.with_index.inject(self) do |result, (key, i)|
```

While actually functioning as expected, and just making sure to end the block with a final call of `result`, the combination of having to do `.each`, `.with_index`, and `.inject` to achieve having both a indexed loop and a resulting object actually caused some extra objects to be
created.

Being explicit here and avoiding the ruby convenience methods seemed to both prevent extraneous objects instantiation and provide the results expected.


Benchmarks
----------

I used the existing benchmarks for https://github.com/ManageIQ/more_core_extensions/pull/54 (an effort originating from https://github.com/ManageIQ/manageiq/pull/15757) as a base, and applied these changes on top of them when doing the benchmarks to see the over all effect.

|                                     | Total Mem Allocated | Total Objects Allocated |
| ----------------------------------- | ------------------- | ----------------------- |
| BEFORE                              | 68871116 bytes      | 854336 objects          |
| AFTER #54                           | 64535996 bytes      | 745958 objects          |
| AFTER #54 & #55 (using `.inject`)   | 66617276 bytes      | 749166 objects          |
| AFTER #54 & #55 (without `.inject`) | 62531396 bytes      | 695843 objects          |


Comparing the objects allocated by gem, we can see that `more_core_extensions` is the only one to change and improve between runs:

```
BEFORE                                               AFTER PR #54                                         AFTER PR #54 & #55

allocated objects by gem                           | allocated objects by gem                           | allocated objects by gem                           
-----------------------------------                | -----------------------------------                | -----------------------------------
    220461  activerecord-5.0.5                     |     220461  activerecord-5.0.5                     |     220461  activerecord-5.0.5
    178489  more_core_extensions-3.3.0  <<<<<<     |     125700  activesupport-5.0.5                    |     125700  activesupport-5.0.5
    123360  activesupport-5.0.5                    |      77606  ruby-2.3.3/lib                         |      77606  ruby-2.3.3/lib
     77606  ruby-2.3.3/lib                         |      70824  manageiq-providers-vmware-b45ffbbaefb3 |      70824  manageiq-providers-vmware-b45ffbbaefb3
     70824  manageiq-providers-vmware-b45ffbbaefb3 |      67771  more_core_extensions/lib  <<<<<<       |      56948  manageiq/app
     56948  manageiq/app                           |      56948  manageiq/app                           |      33983  activemodel-5.0.5
     33983  activemodel-5.0.5                      |      33983  activemodel-5.0.5                      |      31718  manageiq/lib
     31718  manageiq/lib                           |      31718  manageiq/lib                           |      25557  pending
     25557  pending                                |      25557  pending                                |      24228  arel-7.1.4
     24228  arel-7.1.4                             |      24228  arel-7.1.4                             |      17656  more_core_extensions/lib  <<<<<<
      4675  american_date-1.1.1                    |       4675  american_date-1.1.1                    |       4675  american_date-1.1.1
      4125  other                                  |       4125  other                                  |       4125  other
      1804  fast_gettext-1.2.0                     |       1804  fast_gettext-1.2.0                     |       1804  fast_gettext-1.2.0
       555  tzinfo-1.2.3                           |        555  tzinfo-1.2.3                           |        555  tzinfo-1.2.3
         2  default_value_for-3.0.2                |          2  default_value_for-3.0.2                |          2  default_value_for-3.0.2
         1  config-1.3.0                           |          1  config-1.3.0                           |          1  config-1.3.0
```


Links
-----
* Where the issue was noticed:  https://github.com/ManageIQ/manageiq/pull/15757
* Change that cause this to be noticable:  https://github.com/ManageIQ/manageiq/pull/15710
* Similar fix to `more_core_extensions`:  https://github.com/ManageIQ/more_core_extensions/pull/54