### PR TITLE
Reduce rounding errors in .decimal_si_to_f, add safe .decimal_si_to_bigdecimal

### DIFF
--- a/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
+++ b/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
@@ -19,7 +19,7 @@ module MoreCoreExtensions
     def decimal_si_to_scientific_notation
       multiplier = DECIMAL_SUFFIXES[self[-1]]
       if multiplier
-        self[0..-2] + multiplier
+        "#{self[0..-2]}#{multiplier}"
       else
         self
       end

--- a/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
+++ b/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
@@ -1,12 +1,13 @@
 module MoreCoreExtensions
   module DecimalSI
-    DECIMAL_SUFFIXES = {"d" => 1e-1, "c" => 1e-2, "m" => 1e-3, "μ" => 1e-6, "n" => 1e-9, "p" => 1e-12, "f" => 1e-15,
-                        "a" => 1e-18, "h" => 1e2, "k" => 1e3, "M" => 1e6, "G" => 1e9, "T" => 1e12, "P" => 1e15,
-                        "E" => 1e18}.freeze
+    DECIMAL_SUFFIXES = {"d" => "e-1", "c" => "e-2", "m" => "e-3", "μ" => "e-6", "n" => "e-9", "p" => "e-12", "f" => "e-15",
+                        "a" => "e-18", "h" => "e2", "k" => "e3", "M" => "e6", "G" => "e9", "T" => "e12", "P" => "e15",
+                        "E" => "e18"}.freeze
+
     def decimal_si_to_f
       multiplier = DECIMAL_SUFFIXES[self[-1]]
       if multiplier
-        Float(self[0..-2]) * multiplier
+        Float(self[0..-2] + multiplier)
       else
         Float(self)
       end

--- a/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
+++ b/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
@@ -1,3 +1,5 @@
+require 'bigdecimal'
+
 module MoreCoreExtensions
   module DecimalSI
     DECIMAL_SUFFIXES = {"d" => "e-1", "c" => "e-2", "m" => "e-3", "μ" => "e-6", "n" => "e-9", "p" => "e-12", "f" => "e-15",
@@ -5,11 +7,21 @@ module MoreCoreExtensions
                         "E" => "e18"}.freeze
 
     def decimal_si_to_f
+      Float(decimal_si_to_scientific_notation)
+    end
+
+    def decimal_si_to_bigdecimal
+      BigDecimal(decimal_si_to_scientific_notation)
+    end
+
+    private
+
+    def decimal_si_to_scientific_notation
       multiplier = DECIMAL_SUFFIXES[self[-1]]
       if multiplier
-        Float(self[0..-2] + multiplier)
+        self[0..-2] + multiplier
       else
-        Float(self)
+        self
       end
     end
   end

--- a/spec/core_ext/string/decimal_suffix_spec.rb
+++ b/spec/core_ext/string/decimal_suffix_spec.rb
@@ -44,4 +44,20 @@ describe String do
       end
     end
   end
+
+  def strip_zeros(digits)
+    expect(digits).to include(".")
+    digits.sub(/^0*/, "").sub(/0*$/, "")
+  end
+
+  INPUTS_AND_EXPECTED_PATTERNS.each do |input_ij, expected_ij|
+    it "#{input_ij.inspect}.decimal_si_to_bigdecimal -> #{expected_ij} for all i,j" do
+      each_ij(input_ij, expected_ij) do |input, expected_as_string|
+        actual = input.decimal_si_to_bigdecimal
+        expect(actual).to be_a(BigDecimal)
+        expect(actual).to eq(BigDecimal(expected_as_string))
+        expect(strip_zeros(actual.to_s("F"))).to eq(strip_zeros(expected_as_string))
+      end
+    end
+  end
 end

--- a/spec/core_ext/string/decimal_suffix_spec.rb
+++ b/spec/core_ext/string/decimal_suffix_spec.rb
@@ -1,21 +1,47 @@
+# -*- coding: utf-8 -*-
 describe String do
-  it '#decimal_si_to_f' do
-    expect("1f".decimal_si_to_f).to eq(0.000_000_000_000_001)
-    expect("1p".decimal_si_to_f).to eq(0.000_000_000_001)
-    expect("1n".decimal_si_to_f).to eq(0.000_000_001)
-    expect("1μ".decimal_si_to_f).to eq(0.000_001)
-    expect("1m".decimal_si_to_f).to eq(0.001)
-    expect("1c".decimal_si_to_f).to eq(0.01)
-    expect("1d".decimal_si_to_f).to eq(0.1)
-    expect("1".decimal_si_to_f).to  eq(1.0)
-    expect("1k".decimal_si_to_f).to eq(1_000.0)
-    expect("1M".decimal_si_to_f).to eq(1_000_000.0)
-    expect("1G".decimal_si_to_f).to eq(1_000_000_000.0)
-    expect("1T".decimal_si_to_f).to eq(1_000_000_000_000.0)
-    expect("1P".decimal_si_to_f).to eq(1_000_000_000_000_000.0)
-    expect("1E".decimal_si_to_f).to eq(1_000_000_000_000_000_000.0)
+  INPUTS_AND_EXPECTED_PATTERNS = {
+    # These are unsafe to be computed via integer * factor.
+    # Each would fail for some i, j, for example 87 * 0.001 != 0.087.
+    "ijf"   => "0.000_000_000_000_0ij",
+    "ijp"   => "0.000_000_000_0ij",
+    "ijn"   => "0.000_000_0ij",
+    "ijμ"   => "0.000_0ij",
+    "ijm"   => "0.0ij",
+    "ijc"   => "0.ij",
+    "ijd"   => "i.j",
 
-    expect("1e9".decimal_si_to_f).to eq(1_000_000_000.0)
-    expect("1e-9".decimal_si_to_f).to eq(0.000_000_001)
+    # These are less sensitive, safe to compute by multiplication.
+    "ij"    => "ij.0",
+    "ijk"   => "ij_000.0",
+    "ijM"   => "ij_000_000.0",
+    "ijG"   => "ij_000_000_000.0",
+    "ijT"   => "ij_000_000_000_000.0",
+    "ijP"   => "ij_000_000_000_000_000.0",
+    "ijE"   => "ij_000_000_000_000_000_000.0",
+
+    # Not SI suffixes, just fallback to ruby float parsing.
+    "ije9"  => "ij_000_000_000.0",
+    "0i.j0" => "i.j",
+    "ije-9" => "0.000_000_0ij",
+  }.freeze
+
+  def each_ij(input_ij, expected_ij)
+    (0..9).each do |i|
+      (0..9).each do |j|
+        yield(input_ij.sub("i", i.to_s).sub("j", j.to_s),
+              expected_ij.delete("_").sub("i", i.to_s).sub("j", j.to_s))
+      end
+    end
+  end
+
+  INPUTS_AND_EXPECTED_PATTERNS.each do |input_ij, expected_ij|
+    it "#{input_ij.inspect}.decimal_si_to_f -> #{expected_ij} for all i,j" do
+      each_ij(input_ij, expected_ij) do |input, expected_as_string|
+        actual = input.decimal_si_to_f
+        expect(actual).to be_a(Float)
+        expect(actual).to eq(Float(expected_as_string))
+      end
+    end
   end
 end


### PR DESCRIPTION
Currently "87m".decimal_si_to_f == 0.08700000000000001 != 0.087, due to rounding error in multiplication.  Many values do result in a "clean" float¹, but around 10%-20% are dirty like this.  This PR tries to fix that, and also sidesteps the problem by adding an inherently safe `.decimal_si_to_bigdecimal`.

¹ Remember that decimal fractions like 0.087 don't have a precise representation in binary floating point; however there *is* a close float that 0.087 parses to, that also prints back as exactly 0.087, and that's what I'm after — at least being able to print back inputs as we got them.

- Changed all fractions in test to "dirty" ones, failing on current implementation.
- Changed implementation to run `Float("87e-3")` instead of `Float(87) * 1e-3`.
  *Seems* to behave well.  Will break with too many decimal digits, around 18.
- Added inherently safe `.decimal_si_to_bigdecimal`.
  - Returned decimal precicion will depend on input, but is guaranteed to preserve input digits.

https://bugzilla.redhat.com/show_bug.cgi?id=1504560
@miq-bot add-label bug, gaprindashvili/yes

The only use of this method in ManageIQ is for parsing fractional cpu in millicores.
My main motivation is quota history, see https://github.com/ManageIQ/manageiq-providers-kubernetes/issues/208.  While errors here don't affect quotas much after https://github.com/ManageIQ/manageiq-schema/pull/151, because the DB would round small errors from parsing to closest millis, and the _to_f fix here should be enough, I prefer to switch to `.decimal_si_to_bigdecimal` for quotas.

@zeari Please review.