### PR TITLE
Add Class#hierarchy and Class#lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ MoreCoreExtensions are a set of core extensions beyond those provided by ActiveS
 * core_ext/array/tableize.rb
   * `#tableize` - Create a string representation of receiver in a tabular format if receiver is an Array of Arrays or an Array of Hashes
 
+#### Class
+
+* core_ext/class/hierarchy.rb
+  * `#hierarchy` - Returns a tree-like Hash structure of all descendants.
+  * `#lineage` - Returns an Array of all superclasses.
+
 #### Hash
 
 * core_ext/hash/deletes.rb

--- a/lib/more_core_extensions/all.rb
+++ b/lib/more_core_extensions/all.rb
@@ -1,6 +1,7 @@
 require 'more_core_extensions/version'
 
 require 'more_core_extensions/core_ext/array'
+require 'more_core_extensions/core_ext/class'
 require 'more_core_extensions/core_ext/hash'
 require 'more_core_extensions/core_ext/module'
 require 'more_core_extensions/core_ext/numeric'

--- a/lib/more_core_extensions/core_ext/class.rb
+++ b/lib/more_core_extensions/core_ext/class.rb
@@ -1,0 +1,1 @@
+require 'more_core_extensions/core_ext/class/hierarchy'

--- a/lib/more_core_extensions/core_ext/class/hierarchy.rb
+++ b/lib/more_core_extensions/core_ext/class/hierarchy.rb
@@ -1,0 +1,30 @@
+require 'active_support/core_ext/class/subclasses'
+require 'active_support/core_ext/object/try'
+
+module MoreCoreExtensions
+  module ClassHierarchy
+    # Returns a tree-like Hash structure of all descendants.
+    #
+    #   require 'socket'
+    #   IO.hierarchy
+    #   # => {BasicSocket=>
+    #   #      {Socket=>{},
+    #   #       IPSocket=>{TCPSocket=>{TCPServer=>{}}, UDPSocket=>{}},
+    #   #       UNIXSocket=>{UNIXServer=>{}}},
+    #   #     File=>{}}
+    def hierarchy
+      subclasses.each_with_object({}) { |k, h| h[k] = k.hierarchy }
+    end
+
+    # Returns an Array of all superclasses.
+    #
+    #   require 'socket'
+    #   TCPServer.lineage
+    #   # => [TCPSocket, IPSocket, BasicSocket, IO, Object, BasicObject]
+    def lineage
+      superclass.nil? ? [] : superclass.lineage.unshift(superclass)
+    end
+  end
+end
+
+Class.send(:include, MoreCoreExtensions::ClassHierarchy)

--- a/spec/core_ext/class/hierarchy_spec.rb
+++ b/spec/core_ext/class/hierarchy_spec.rb
@@ -1,0 +1,18 @@
+require 'socket' # for a more interesting hierarchy for specs
+
+describe Class do
+  it "#hierarchy" do
+    expect(IO.hierarchy).to eq(
+      BasicSocket => {
+        Socket     => {},
+        IPSocket   => {TCPSocket => {TCPServer => {}}, UDPSocket => {}},
+        UNIXSocket => {UNIXServer => {}}
+      },
+      File        => {}
+    )
+  end
+
+  it "#lineage" do
+    expect(TCPServer.lineage).to eq [TCPSocket, IPSocket, BasicSocket, IO, Object, BasicObject]
+  end
+end


### PR DESCRIPTION
@bdunne Please review.  See specs for examples.

I frequently need this in order to understand a given OO class hierarchy or lineage, so this is probably mostly for diagnostic usage, but useful nonetheless.


```ruby
require 'socket'

IO.hierarchy
# => {BasicSocket=>
#      {Socket=>{},
#       IPSocket=>{TCPSocket=>{TCPServer=>{}}, UDPSocket=>{}},
#       UNIXSocket=>{UNIXServer=>{}}},
#     File=>{}}

TCPServer.lineage
# => [TCPSocket, IPSocket, BasicSocket, IO, Object, BasicObject]
```