### PR TITLE
Add Array#compact_map

### DIFF
--- a/lib/more_core_extensions/core_ext/array.rb
+++ b/lib/more_core_extensions/core_ext/array.rb
@@ -1,3 +1,4 @@
+require 'more_core_extensions/core_ext/array/compact_map'
 require 'more_core_extensions/core_ext/array/deletes'
 require 'more_core_extensions/core_ext/array/duplicates'
 require 'more_core_extensions/core_ext/array/element_counts'

--- a/lib/more_core_extensions/core_ext/array/compact_map.rb
+++ b/lib/more_core_extensions/core_ext/array/compact_map.rb
@@ -1,0 +1,19 @@
+module MoreCoreExtensions
+  module ArrayCompactMap
+    # Collect non-nil results from the block.  Basically [].collect { |i| ... }.compact
+    #
+    #   [1,2,3,4,5].compact_map { |i| i * 2 if i.odd?} # => [2,6,10]
+    def compact_map
+      return enum_for(:compact_map) unless block_given?
+
+      [].tap do |results|
+        each do |i|
+          result = yield(i)
+          results << result if result
+        end
+      end
+    end
+  end
+end
+
+Array.send(:include, MoreCoreExtensions::ArrayCompactMap)

--- a/spec/core_ext/array/compact_map_spec.rb
+++ b/spec/core_ext/array/compact_map_spec.rb
@@ -1,0 +1,7 @@
+describe Array do
+  it "#compact_map" do
+    expect([].compact_map).to be_kind_of(Enumerable)
+    expect([].compact_map { |i| i * 2 if i.odd? }).to eq([])
+    expect([1, 2, 3, 4, 5].compact_map { |i| i * 2 if i.odd? }).to eq([2, 6, 10])
+  end
+end


### PR DESCRIPTION
Too many times I find myself enumerating over an array wanting some transformed data and no `nil`s.  So, I wind up with something like this:
```ruby
[1,2,3,4,5].collect { |i| i * 2 if i.odd? }.compact
=> [2,6,10]
```

Instead, we can have:
```ruby
[1,2,3,4,5].compact_map { |i| i * 2 if i.odd? }
=> [2,6,10]
```
This avoids allocating an extra array before the compact
