### PR TITLE
 Extract Benchmark.realtime_store/block from manageiq-gems-pending

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "more_core_extensions"
+require "more_core_extensions/all"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/more_core_extensions/all.rb
+++ b/lib/more_core_extensions/all.rb
@@ -1,6 +1,7 @@
 require 'more_core_extensions/version'
 
 require 'more_core_extensions/core_ext/array'
+require 'more_core_extensions/core_ext/benchmark'
 require 'more_core_extensions/core_ext/class'
 require 'more_core_extensions/core_ext/hash'
 require 'more_core_extensions/core_ext/module'

--- a/lib/more_core_extensions/core_ext/benchmark.rb
+++ b/lib/more_core_extensions/core_ext/benchmark.rb
@@ -1,0 +1,1 @@
+require 'more_core_extensions/core_ext/benchmark/realtime_store'

--- a/lib/more_core_extensions/core_ext/benchmark/realtime_store.rb
+++ b/lib/more_core_extensions/core_ext/benchmark/realtime_store.rb
@@ -35,9 +35,8 @@ module MoreCoreExtensions
           begin
             ret = realtime_store(hash, key, &block)
             return ret, hash
-          rescue Exception
-            # Don't let timings be lost on exception when there is nobody else to pick them up.
-            logger.info("Exception in realtime_block #{key.inspect} - Timings: #{hash.inspect}")
+          rescue Exception => err # rubocop:disable Lint/RescueException
+            err.define_singleton_method(:timings) { hash } unless err.respond_to?(:timings)
             raise
           ensure
             delete_current_realtime
@@ -73,12 +72,6 @@ module MoreCoreExtensions
       @@realtime_by_tid.delete(thread_unique_identifier)
     end
 
-    private def logger
-      @logger ||= begin
-        require 'logger'
-        $log || Logger.new($stderr)
-      end
-    end
 
     @@realtime_by_tid = {}
   end

--- a/lib/more_core_extensions/core_ext/benchmark/realtime_store.rb
+++ b/lib/more_core_extensions/core_ext/benchmark/realtime_store.rb
@@ -1,0 +1,87 @@
+require 'benchmark'
+
+module MoreCoreExtensions
+  module BenchmarkRealtimeStore
+    # Stores the elapsed real time used to execute the given block in the given
+    # hash for the given key and returns the result from the block.  If the hash
+    # already has a value for that key, the time is accumulated.
+    def realtime_store(hash, key)
+      ret = nil
+      r0 = Time.now
+      begin
+        ret = yield
+      ensure
+        r1 = Time.now
+        hash[key] = (hash[key] || 0) + (r1.to_f - r0.to_f)
+      end
+      ret
+    end
+
+    # Stores the elapsed real time used to execute the given block for the given
+    # key and returns the hash as well as the result from the block.  The hash is
+    # stored globally, keyed on thread id, and is cleared once the topmost nested
+    # call completes.  If the hash already has a value for that key, the time is
+    # accumulated.
+    def realtime_block(key, &block)
+      hash = current_realtime
+
+      if in_realtime_block?
+        ret = realtime_store(hash, key, &block)
+        return ret, hash
+      else
+        # Outermost block.
+        begin
+          self.current_realtime = hash
+          begin
+            ret = realtime_store(hash, key, &block)
+            return ret, hash
+          rescue Exception
+            # Don't let timings be lost on exception when there is nobody else to pick them up.
+            logger.info("Exception in realtime_block #{key.inspect} - Timings: #{hash.inspect}")
+            raise
+          ensure
+            delete_current_realtime
+          end
+        ensure
+          # A second layer of protection in case TimeoutError struck right after
+          # setting self.current_realtime, or right before `delete_current_realtime`.
+          # In those cases, current_realtime might (wrongly) still exist.
+          delete_current_realtime if in_realtime_block?
+        end
+      end
+    end
+
+    def thread_unique_identifier
+      # Forks inherit the @@realtime_by_tid and parent/child Thread.current.object_id
+      # are equal, so we need to index into the hash with the pid too.
+      "#{Process.pid}-#{Thread.current.object_id}"
+    end
+
+    def in_realtime_block?
+      @@realtime_by_tid.key?(thread_unique_identifier)
+    end
+
+    def current_realtime
+      @@realtime_by_tid[thread_unique_identifier] || Hash.new(0)
+    end
+
+    def current_realtime=(hash)
+      @@realtime_by_tid[thread_unique_identifier] = hash
+    end
+
+    def delete_current_realtime
+      @@realtime_by_tid.delete(thread_unique_identifier)
+    end
+
+    private def logger
+      @logger ||= begin
+        require 'logger'
+        $log || Logger.new($stderr)
+      end
+    end
+
+    @@realtime_by_tid = {}
+  end
+end
+
+Benchmark.send(:extend, MoreCoreExtensions::BenchmarkRealtimeStore)

--- a/spec/core_ext/benchmark/realtime_store_spec.rb
+++ b/spec/core_ext/benchmark/realtime_store_spec.rb
@@ -1,0 +1,131 @@
+require 'timecop'
+require 'timeout'
+
+describe Benchmark do
+  after(:each) { Timecop.return }
+  after(:each) do
+    # Isolate other tests
+    Benchmark.delete_current_realtime if Benchmark.in_realtime_block?
+  end
+
+  it '.realtime_store' do
+    timings = {}
+    result = Benchmark.realtime_store(timings, :test1) do
+      Timecop.travel(500)
+      Benchmark.realtime_store(timings, :test2) do
+        Timecop.travel(500)
+        Benchmark.realtime_store(timings, :test3) do
+          Timecop.travel(500)
+        end
+      end
+      "test"
+    end
+    expect(result).to eq("test")
+    expect(timings[:test1]).to be_within(0.5).of(1500)
+    expect(timings[:test2]).to be_within(0.5).of(1000)
+    expect(timings[:test3]).to be_within(0.5).of(500)
+  end
+
+  it '.realtime_store with an Exception' do
+    timings = {}
+    begin
+      Benchmark.realtime_store(timings, :test1) do
+        Timecop.travel(500)
+        raise Exception
+      end
+    rescue Exception
+      expect(timings[:test1]).to be_within(0.5).of(500)
+    end
+  end
+
+  it '.realtime_block' do
+    result, timings = Benchmark.realtime_block(:test1) do
+      Timecop.travel(500)
+      Benchmark.realtime_block(:test2) do
+        Timecop.travel(500)
+        Benchmark.realtime_block(:test3) do
+          Timecop.travel(500)
+        end
+      end
+      "test"
+    end
+    expect(result).to eq("test")
+    expect(timings[:test1]).to be_within(0.5).of(1500)
+    expect(timings[:test2]).to be_within(0.5).of(1000)
+    expect(timings[:test3]).to be_within(0.5).of(500)
+  end
+
+  it '.in_realtime_block?' do
+    expect(Benchmark.in_realtime_block?).to be_falsey
+    Benchmark.realtime_block(:test1) do
+      expect(Benchmark.in_realtime_block?).to be_truthy
+    end
+    expect(Benchmark.in_realtime_block?).to be_falsey
+  end
+
+  it '.realtime_block with an Exception aborting outermost block' do
+    expect(Benchmark.send(:logger)).to receive(:info).with(/Exception in realtime_block :test1 - Timings: {:test2=>5\.\d*, :test1=>7\.\d*}/)
+    expect do
+      Benchmark.realtime_block(:test1) do
+        Timecop.travel(2.1)
+        Benchmark.realtime_block(:test2) do
+          Timecop.travel(5.1)
+          raise Exception
+        end
+      end
+    end.to raise_exception(Exception)
+
+    expect(Benchmark.in_realtime_block?).to be_falsey
+  end
+
+  it '.realtime_block with an Exception caught in inner block' do
+    result = timings = nil
+    expect do
+      result, timings = Benchmark.realtime_block(:test1) do
+        begin
+          Timecop.travel(500)
+          Benchmark.realtime_block(:test2) do
+            Timecop.travel(500)
+            raise Exception
+          end
+        rescue Exception
+          "value"
+        end
+      end
+    end.to_not output.to_stderr
+
+    expect(result).to eq("value")
+    expect(timings[:test1]).to be_within(0.5).of(1000)
+    expect(timings[:test2]).to be_within(0.5).of(500)
+    expect(Benchmark.in_realtime_block?).to be_falsey
+  end
+
+  it "Timeout raising within .realtime_block" do
+    expect(Benchmark.in_realtime_block?).to be_falsey
+
+    # If something left over from previous tests gets GC'd during Timeout, its finalizer may
+    # be interrupted.  For example, interrupted Temfile cleanup may get stuck forever!
+    # This reduces chance of nasty interactions...
+    GC.start
+
+    20.times do |i|
+      begin
+        # keep entering/exiting, abort ASAP
+        Timeout.timeout(1e-9) do
+          2_000_000.times do
+            Benchmark.realtime_block(:test1) do
+              Benchmark.realtime_block(:test2) do
+              end
+              "result"
+            end
+          end
+        end
+        raise("Completed without Timeout!?  Tip: may result from unclosed Tempfile object.")
+      rescue Timeout::Error => e
+        where = e.backtrace.first(10).join("\n")
+        expect(Benchmark.in_realtime_block?).to be_falsey,
+                                                "failed on #{i}th Timeout, #{e.inspect} interrupted in:\n#{where}"
+      end
+    end
+  end
+end

--- a/spec/core_ext/benchmark/realtime_store_spec.rb
+++ b/spec/core_ext/benchmark/realtime_store_spec.rb
@@ -64,7 +64,6 @@ describe Benchmark do
   end
 
   it '.realtime_block with an Exception aborting outermost block' do
-    expect(Benchmark.send(:logger)).to receive(:info).with(/Exception in realtime_block :test1 - Timings: {:test2=>5\.\d*, :test1=>7\.\d*}/)
     expect do
       Benchmark.realtime_block(:test1) do
         Timecop.travel(2.1)


### PR DESCRIPTION
@bdunne @jrafanie Please review.

Note a change from the original [[ref]](https://github.com/ManageIQ/more_core_extensions/pull/65/files#diff-f710a3beaafd651ce21c2bc3ec479fe7R65) ...previously this registered a logger and logged exceptions.  Instead, at the library level it makes more sense to me that the caller handle the logging.  So as not to lose the timings, however, we can modify the exception to add the timing metadata to it.