### PR TITLE
Updated documentation and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.0.0] - 2019-12-11
+### Changed
+- **BREAKING**: Renamed Enumerable#stable_sort_by to Array#tabular_sort [[#68](https://github.com/ManageIQ/more_core_extensions/pull/68)]
+
+### Added
+- Added Class#leaf_subclasses [[#71](https://github.com/ManageIQ/more_core_extensions/pull/71)]
+- Added Array#compact_map [[#63](https://github.com/ManageIQ/more_core_extensions/pull/63)]
+
 ## [3.7.0] - 2019-02-04
 ### Added
 - Added Enumerable#stable_sort_by [[#67](https://github.com/ManageIQ/more_core_extensions/pull/67)]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ MoreCoreExtensions are a set of core extensions beyond those provided by ActiveS
 
 #### Array
 
+* core_ext/array/compact_map.rb
+  * `#compact_map` - Collect non-nil results from the block
 * core_ext/array/deletes.rb
   * `#delete_blanks` - Deletes all items where the value is blank
   * `#delete_nils` - Deletes all items where the value is nil
@@ -35,6 +37,8 @@ MoreCoreExtensions are a set of core extensions beyond those provided by ActiveS
 * core_ext/array/random.rb
   * `#random_index` - Picks a valid index randomly
   * `#random_element` - Picks an element randomly
+* core_ext/array/sorting.rb
+  * `#tabular_sort` - Sorts an Array of Hashes by specific columns
 * core_ext/array/stretch.rb
   * `.stretch` - Stretch all argument Arrays to make them the same size
   * `.stretch!` - Stretch all argument Arrays to make them the same size. Modifies the arguments in place.

--- a/lib/more_core_extensions/core_ext/array/sorting.rb
+++ b/lib/more_core_extensions/core_ext/array/sorting.rb
@@ -1,5 +1,27 @@
 module MoreCoreExtensions
   module StableSorting
+    # Sorts an Array of Hashes by specific columns.
+    #
+    # Rows are sorted by +col_names+, if given, otherwise by the given block.
+    #   The +order+ parameter can be given :ascending or :descending and
+    #   defaults to :ascending.
+    #
+    # Note:
+    # - Strings are sorted case-insensitively
+    # - nil values are sorted last
+    # - Boolean values are sorted alphabetically (i.e. false then true)
+    #
+    #   [
+    #     {:col1 => 'b', :col2 => 2},
+    #     {:col1 => 'b', :col2 => 1},
+    #     {:col1 => 'A', :col2 => 1}
+    #   ].tabular_sort([:col1, :col2])
+    #
+    #   # => [
+    #   #   {:col1 => 'A', :col2 => 1},
+    #   #   {:col1 => 'b', :col2 => 1},
+    #   #   {:col1 => 'b', :col2 => 2}
+    #   # ]
     def tabular_sort(col_names = nil, order = nil, &block)
       # stabilizer is needed because of
       # http://blade.nagaokaut.ac.jp/cgi-bin/scat.rb/ruby/ruby-talk/170565


### PR DESCRIPTION
@bdunne Please review.

I was about to release this as 4.0.0, but wanted your opinion first on the breaking change.

I can release as is, or alternately what I can do is create an Enumerable#stable_sort_by method that is deprecated and just calls Array#tabular_sort .  This way we could release a 3.8.0 to bring in the other changes, and then after release a 4.0.0 with the breaking change.  WDYT?