### PR TITLE
Add a brief sleep call to ensure process is paused

### DIFF
--- a/spec/core_ext/process/pause_resume_spec.rb
+++ b/spec/core_ext/process/pause_resume_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe Process do
     it "can resume a paused process" do
       expect(get_process_status(@pid)).to eql(paused_status)
       Process.resume(@pid)
+      sleep 0.5 # Give the kernel a chance to update the status
       expect(get_process_status(@pid)).not_to eql(paused_status)
     end
 

--- a/spec/core_ext/process/pause_resume_spec.rb
+++ b/spec/core_ext/process/pause_resume_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Process do
     it "can pause a running process" do
       expect(get_process_status(@pid)).not_to eql(paused_status)
       expect(Process.pause(@pid)).to eql(1)
+      sleep 0.5 # Give the kernel a chance to update the status
       expect(get_process_status(@pid)).to eql(paused_status)
     end
 


### PR DESCRIPTION
Currently we have a race condition in the Process pause/resume specs where the status isn't updated in time for the status check. So, this PR introduces a small sleep call so that the OS has had a chance to update the status before we check for it.