### PR TITLE
Update pause/resume specs to use ps command

### DIFF
--- a/more_core_extensions.gemspec
+++ b/more_core_extensions.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0"
   spec.add_development_dependency "simplecov"
-  spec.add_development_dependency "sys-proctable", "~> 1.2.2"
   spec.add_development_dependency "timecop"
 
   spec.add_runtime_dependency "activesupport"

--- a/spec/core_ext/process/pause_resume_spec.rb
+++ b/spec/core_ext/process/pause_resume_spec.rb
@@ -1,6 +1,4 @@
 RSpec.describe Process do
-  let(:linux) { Gem::Platform.local.os == 'linux' }
-
   def get_process_status(pid)
     `ps -p #{pid} -o stat=`.chomp.split('').first
   end

--- a/spec/core_ext/process/pause_resume_spec.rb
+++ b/spec/core_ext/process/pause_resume_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Process do
     it "can pause a running process" do
       expect(get_process_status(@pid)).not_to eql(paused_status)
       expect(Process.pause(@pid)).to eql(1)
-      sleep 0.5 # Give the kernel a chance to update the status
+      sleep 1.1 # Give the kernel a chance to update the status
       expect(get_process_status(@pid)).to eql(paused_status)
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Process do
     it "can resume a paused process" do
       expect(get_process_status(@pid)).to eql(paused_status)
       Process.resume(@pid)
-      sleep 0.5 # Give the kernel a chance to update the status
+      sleep 1.1 # Give the kernel a chance to update the status
       expect(get_process_status(@pid)).not_to eql(paused_status)
     end
 

--- a/spec/core_ext/process/pause_resume_spec.rb
+++ b/spec/core_ext/process/pause_resume_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe Process do
     end
 
     it "can pause a running process" do
-      expect(get_process_status(@pid)).not_to eql('T')
+      expect(get_process_status(@pid)).not_to eq('T')
       expect(Process.pause(@pid)).to eql(1)
-      expect(get_process_status(@pid)).to eql('T')
+      expect(get_process_status(@pid)).to eq('T')
     end
 
     it "is a no-op if the process is already paused" do
-      expect(Process.pause(@pid)).to eql(1)
+      expect(Process.pause(@pid)).to eq(1)
       expect { Process.pause(@pid) }.not_to raise_error
-      expect(Process.pause(@pid)).to eql(1)
+      expect(Process.pause(@pid)).to eq(1)
     end
 
     it "returns nil if the process is not running" do
@@ -48,15 +48,15 @@ RSpec.describe Process do
     end
 
     it "can resume a paused process" do
-      expect(get_process_status(@pid)).to eql('T')
+      expect(get_process_status(@pid)).to eq('T')
       Process.resume(@pid)
-      expect(get_process_status(@pid)).not_to eql('T')
+      expect(get_process_status(@pid)).not_to eq('T')
     end
 
     it "is a no-op if the process is already running" do
-      expect(Process.resume(@pid)).to eql(1)
+      expect(Process.resume(@pid)).to eq(1)
       expect { Process.resume(@pid) }.not_to raise_error
-      expect(Process.resume(@pid)).to eql(1)
+      expect(Process.resume(@pid)).to eq(1)
     end
 
     it "returns nil if the process is not running" do

--- a/spec/core_ext/process/pause_resume_spec.rb
+++ b/spec/core_ext/process/pause_resume_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Process do
   def get_process_status(pid)
-    `ps -p #{pid} -o stat=`.chomp.split('').first
+    `ps -p #{pid} -o stat=`[0]
   end
 
   context ".alive?" do


### PR DESCRIPTION
Followup to #82, let's increase the sleep call slightly since I think Linux updates the proc info once per second, so a half second might not be enough.

Edit: I think it's a race condition with sys-proctable. So, let's just use `ps` instead.