### PR TITLE
remove deprecated ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,15 @@
 language: ruby
+dist: xenial
 rvm:
-  - "2.0"
-  - "2.1.10"
-  - "2.2.10"
-  - "2.3.8"
-  - "2.4.5"
-  - "2.5.3"
-  - "2.6.0"
-  - "2.7.0"
+  - "2.5.8"
+  - "2.6.6"
+  - "2.7.1"
   - ruby-head
   - jruby-head
-sudo: false
 cache: bundler
 after_script: bundle exec codeclimate-test-reporter
 matrix:
   allow_failures:
-    - rvm: "2.6.0"
     - rvm: ruby-head
     - rvm: jruby-head
   fast_finish: true


### PR DESCRIPTION
Per [ruby-lang] 2.4 is completely unsupported, and 2.5.x only gets security fixes.
I am suggesting dropping these to use fewer cycles in PRs. But there may be other reasons to support older versions of ruby.

This also upgrades the travis build environment to the latest.

[ruby-lang]: https://www.ruby-lang.org/en/downloads/branches/