### PR TITLE
maintain version consistency with the rest of the repos

### DIFF
--- a/more_core_extensions.gemspec
+++ b/more_core_extensions.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "timecop"
 
-  spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "activesupport", "~>5.2.4", ">=5.2.4.3"
   spec.add_runtime_dependency "sync"
 end


### PR DESCRIPTION
If we had a min version on activesupport hakiri would still be whining about code injection, just kidding

This keeps the version equivalent to schema


or maybe not since it requires a bundler min too and i dunno if you people are gonna go for that 

Fixes https://hakiri.io/github/ManageIQ/more_core_extensions/master/38a8ce618942656e98a635ca8c5fe633fcc451b4/warnings?name=Code+Injection