### PR TITLE
Update current rubies, loosen older ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,19 @@
 language: ruby
 rvm:
   - "2.0"
-  - "2.1.10"
-  - "2.2.10"
-  - "2.3.8"
-  - "2.4.5"
-  - "2.5.3"
-  - "2.6.0"
-  - "2.7.0"
+  - "2.1"
+  - "2.2"
+  - "2.3"
+  - "2.4"
+  - "2.5.8"
+  - "2.6.6"
+  - "2.7.1"
   - ruby-head
   - jruby-head
-sudo: false
 cache: bundler
 after_script: bundle exec codeclimate-test-reporter
 matrix:
   allow_failures:
-    - rvm: "2.6.0"
     - rvm: ruby-head
     - rvm: jruby-head
   fast_finish: true


### PR DESCRIPTION
2.6 shouldn't be allowed to fail

An alternative to #86 