### PR TITLE
Remove EOL rubies since they fail to bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: ruby
 rvm:
-  - "2.1"
-  - "2.2"
-  - "2.3"
-  - "2.4"
   - "2.5.8"
   - "2.6.6"
-  - "2.7.1"
+  - "2.7.2"
   - ruby-head
   - jruby-head
 cache: bundler


### PR DESCRIPTION
Also, update to latest 2.7