### PR TITLE
Fix issue where tableize would not honor a smaller colored field

### DIFF
--- a/lib/more_core_extensions/core_ext/array/tableize.rb
+++ b/lib/more_core_extensions/core_ext/array/tableize.rb
@@ -123,6 +123,7 @@ module MoreCoreExtensions
       def format_field(field, width, justification)
         field = field.to_s.gsub(/\n|\r/, '')
         field = ansi_truncate(field, width)
+        width += ansi_escapes(field).sum { |f| f.to_s.size }
         "%0#{justification}#{width}s" % field
       end
 

--- a/spec/core_ext/array/tableize_spec.rb
+++ b/spec/core_ext/array/tableize_spec.rb
@@ -133,6 +133,17 @@ EOF
         expect(test.tableize(:max_width => 100)).to eq(expected)
       end
 
+      it 'with really short column value and color' do
+        test = [["Col1", "Col2"], ["\033[31mVal1\e[0m", "Val2"], ["Really Really Long Value3", "Value4"]]
+        expected = <<-EOF
+ Col1                      | Col2
+---------------------------|--------
+ \e[31mVal1\e[0m                      | Val2
+ Really Really Long Value3 | Value4
+EOF
+        expect(test.tableize).to eq(expected)
+      end
+
       it 'with :header => false option' do
         test = [["Col1", "Col2"], ["Val1", "Val2"], ["Value3", "Value4"]]
         expected = <<-EOF


### PR DESCRIPTION
Before

![__dev_more_core_extensions](https://user-images.githubusercontent.com/52120/125364236-1f736380-e340-11eb-9e36-74a4818ebd83.png)

After

![__dev_more_core_extensions](https://user-images.githubusercontent.com/52120/125364311-3ade6e80-e340-11eb-98b6-58a5cd577bb8.png)


@bdunne Please review.