### PR TITLE
Support "1.5Ki" format for iec_60027_2_to_i

### DIFF
--- a/lib/more_core_extensions/core_ext/string/iec60027_2.rb
+++ b/lib/more_core_extensions/core_ext/string/iec60027_2.rb
@@ -10,7 +10,7 @@ module MoreCoreExtensions
       if suffix_index.nil?
         Integer(self)
       else
-        Integer(self[0..-3]) * (2**10)**(suffix_index + 1)
+        Integer(Float(self[0..-3]) * ((2**10)**(suffix_index + 1)))
       end
     end
   end

--- a/spec/core_ext/string/iec60027_2_spec.rb
+++ b/spec/core_ext/string/iec60027_2_spec.rb
@@ -2,6 +2,7 @@ describe String do
   it '#iec60027_2' do
     expect("1   ".iec_60027_2_to_i).to eq(1)
     expect("1 Ki".iec_60027_2_to_i).to eq(1_024)
+    expect("1.5 Ki".iec_60027_2_to_i).to eq(1_536)
     expect("1 Mi".iec_60027_2_to_i).to eq(1_048_576)
     expect("1 Gi".iec_60027_2_to_i).to eq(1_073_741_824)
     expect("1 Ti".iec_60027_2_to_i).to eq(1_099_511_627_776)


### PR DESCRIPTION
Just adding a spec which will fail to show the issue