### PR TITLE
Add Class#hierarchy block support to allow formatting of classes

### DIFF
--- a/lib/more_core_extensions/core_ext/class/hierarchy.rb
+++ b/lib/more_core_extensions/core_ext/class/hierarchy.rb
@@ -22,6 +22,8 @@ module MoreCoreExtensions
 
     # Returns a tree-like Hash structure of all descendants.
     #
+    #   If a block is passed, that block is used to format the keys of the hierarchy
+    #
     #   require 'socket'
     #   IO.hierarchy
     #   # => {BasicSocket=>
@@ -29,8 +31,18 @@ module MoreCoreExtensions
     #   #       IPSocket=>{TCPSocket=>{TCPServer=>{}}, UDPSocket=>{}},
     #   #       UNIXSocket=>{UNIXServer=>{}}},
     #   #     File=>{}}
-    def hierarchy
-      subclasses.each_with_object({}) { |k, h| h[k] = k.hierarchy }
+    #
+    #   IO.hierarchy(&:name)
+    #   # => {"BasicSocket"=>
+    #   #      {"Socket"=>{},
+    #   #       "IPSocket"=>{"TCPSocket"=>{"TCPServer"=>{}}, "UDPSocket"=>{}},
+    #   #       "UNIXSocket"=>{"UNIXServer"=>{}}},
+    #   #     "File"=>{}}
+    def hierarchy(&block)
+      subclasses.each_with_object({}) do |k, h|
+        key = block ? yield(k) : k
+        h[key] = k.hierarchy(&block)
+      end
     end
 
     # Returns an Array of all superclasses.

--- a/spec/core_ext/class/hierarchy_spec.rb
+++ b/spec/core_ext/class/hierarchy_spec.rb
@@ -27,15 +27,28 @@ describe Class do
     end
   end
 
-  it "#hierarchy" do
-    expect(IO.hierarchy).to eq(
-      BasicSocket => {
-        Socket     => {},
-        IPSocket   => {TCPSocket => {TCPServer => {}}, UDPSocket => {}},
-        UNIXSocket => {UNIXServer => {}}
-      },
-      File        => {}
-    )
+  describe "#hierarchy" do
+    it "by default returns a hash of descendants with keys being the classes" do
+      expect(IO.hierarchy).to eq(
+        BasicSocket => {
+          Socket     => {},
+          IPSocket   => {TCPSocket => {TCPServer => {}}, UDPSocket => {}},
+          UNIXSocket => {UNIXServer => {}}
+        },
+        File        => {}
+      )
+    end
+
+    it "with a block returns a hash of descendants with keys being the block evaluation" do
+      expect(IO.hierarchy(&:name)).to eq(
+        "BasicSocket" => {
+          "Socket"     => {},
+          "IPSocket"   => {"TCPSocket" => {"TCPServer" => {}}, "UDPSocket" => {}},
+          "UNIXSocket" => {"UNIXServer" => {}}
+        },
+        "File"        => {}
+      )
+    end
   end
 
   it "#lineage" do


### PR DESCRIPTION
@jrafanie Please review.

This is particularly needed when diagnosing object trees in Rails where Rails wants to print all of the columns of the model objects.  For example, here's our ManageIQ Authentication model before/after:

Before (even better, imagine this word-wrapped to the terminal width in irb):

```
> Authentication.hierarchy
=>
{AuthPrivateKey(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {}},
 AuthToken(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {},
 AuthUseridPassword(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {},
 ManageIQ::Providers::AutomationManager::Authentication(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {ManageIQ::Providers::EmbeddedAutomationManager::Authentication(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
      {ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {}},
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {}},
     ManageIQ::Providers::Workflows::AutomationManager::Credential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
      {ManageIQ::Providers::Workflows::AutomationManager::ScmCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::Workflows::AutomationManager::WorkflowCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {}}},
   ManageIQ::Providers::ExternalAutomationManager::Authentication(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {ManageIQ::Providers::Awx::AutomationManager::Credential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
      {ManageIQ::Providers::AnsibleTower::AutomationManager::Credential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {},
           ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {},
           ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {},
           ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {},
           ManageIQ::Providers::AnsibleTower::AutomationManager::RhvCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {},
           ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {},
           ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
            {}},
         ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::AnsibleTower::AutomationManager::VaultCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {}},
       ManageIQ::Providers::Awx::AutomationManager::CloudCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {ManageIQ::Providers::Awx::AutomationManager::AmazonCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::Awx::AutomationManager::AzureCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::Awx::AutomationManager::GoogleCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::Awx::AutomationManager::OpenstackCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::Awx::AutomationManager::RhvCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::Awx::AutomationManager::Satellite6Credential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {},
         ManageIQ::Providers::Awx::AutomationManager::VmwareCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
          {}},
       ManageIQ::Providers::Awx::AutomationManager::MachineCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::Awx::AutomationManager::NetworkCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::Awx::AutomationManager::ScmCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {},
       ManageIQ::Providers::Awx::AutomationManager::VaultCredential(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
        {}}}},
 ManageIQ::Providers::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {},
   ManageIQ::Providers::Google::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {},
   ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {},
   ManageIQ::Providers::IbmCloud::VPC::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {},
   ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
    {ManageIQ::Providers::IbmCic::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
      {},
     ManageIQ::Providers::IbmPowerVc::CloudManager::AuthKeyPair(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
      {}}},
 ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow::ImageImportAuth(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {},
 ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow::SshPkeyAuth(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {},
 ManageIQ::Providers::IbmPowerVc::CloudManager::PvcImageImportWorkflow::ImageImportAuth(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {},
 ManageIQ::Providers::IbmPowerVc::CloudManager::PvcImageImportWorkflow::SshPkeyAuth(id: integer, name: string, authtype: string, userid: string, password: string, resource_id: integer, resource_type: string, created_on: datetime, updated_on: datetime, last_valid_on: datetime, last_invalid_on: datetime, credentials_changed_on: datetime, status: string, status_details: string, type: string, auth_key: text, fingerprint: string, service_account: string, public_key: text, manager_ref: string, options: text, evm_owner_id: integer, miq_group_id: integer, tenant_id: integer, become_username: string, become_password: string, auth_key_password: string, ems_ref: string, become_method: string, href_slug: string, region_number: integer, region_description: string, owned_by_current_user: boolean, owned_by_current_ldap_group: boolean, evm_owner_email: string, evm_owner_name: string, evm_owner_userid: string, owning_ldap_group: string)=>
  {}}
```

After

```
> Authentication.hierarchy(&:name)
=>
{"AuthPrivateKey"=>{"ManageIQ::Providers::Openstack::InfraManager::AuthKeyPair"=>{}},
 "AuthToken"=>{},
 "AuthUseridPassword"=>{},
 "ManageIQ::Providers::AutomationManager::Authentication"=>
  {"ManageIQ::Providers::EmbeddedAutomationManager::Authentication"=>
    {"ManageIQ::Providers::EmbeddedAnsible::AutomationManager::Credential"=>
      {"ManageIQ::Providers::EmbeddedAnsible::AutomationManager::CloudCredential"=>
        {"ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AmazonCredential"=>{},
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::AzureCredential"=>{},
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::GoogleCredential"=>{},
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::OpenstackCredential"=>{},
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::RhvCredential"=>{},
         "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VmwareCredential"=>{}},
       "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::MachineCredential"=>{},
       "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::NetworkCredential"=>{},
       "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::ScmCredential"=>{},
       "ManageIQ::Providers::EmbeddedAnsible::AutomationManager::VaultCredential"=>{}},
     "ManageIQ::Providers::Workflows::AutomationManager::Credential"=>{"ManageIQ::Providers::Workflows::AutomationManager::ScmCredential"=>{}, "ManageIQ::Providers::Workflows::AutomationManager::WorkflowCredential"=>{}}},
   "ManageIQ::Providers::ExternalAutomationManager::Authentication"=>
    {"ManageIQ::Providers::Awx::AutomationManager::Credential"=>
      {"ManageIQ::Providers::AnsibleTower::AutomationManager::Credential"=>
        {"ManageIQ::Providers::AnsibleTower::AutomationManager::CloudCredential"=>
          {"ManageIQ::Providers::AnsibleTower::AutomationManager::AmazonCredential"=>{},
           "ManageIQ::Providers::AnsibleTower::AutomationManager::AzureCredential"=>{},
           "ManageIQ::Providers::AnsibleTower::AutomationManager::GoogleCredential"=>{},
           "ManageIQ::Providers::AnsibleTower::AutomationManager::OpenstackCredential"=>{},
           "ManageIQ::Providers::AnsibleTower::AutomationManager::RhvCredential"=>{},
           "ManageIQ::Providers::AnsibleTower::AutomationManager::Satellite6Credential"=>{},
           "ManageIQ::Providers::AnsibleTower::AutomationManager::VmwareCredential"=>{}},
         "ManageIQ::Providers::AnsibleTower::AutomationManager::MachineCredential"=>{},
         "ManageIQ::Providers::AnsibleTower::AutomationManager::NetworkCredential"=>{},
         "ManageIQ::Providers::AnsibleTower::AutomationManager::ScmCredential"=>{},
         "ManageIQ::Providers::AnsibleTower::AutomationManager::VaultCredential"=>{}},
       "ManageIQ::Providers::Awx::AutomationManager::CloudCredential"=>
        {"ManageIQ::Providers::Awx::AutomationManager::AmazonCredential"=>{},
         "ManageIQ::Providers::Awx::AutomationManager::AzureCredential"=>{},
         "ManageIQ::Providers::Awx::AutomationManager::GoogleCredential"=>{},
         "ManageIQ::Providers::Awx::AutomationManager::OpenstackCredential"=>{},
         "ManageIQ::Providers::Awx::AutomationManager::RhvCredential"=>{},
         "ManageIQ::Providers::Awx::AutomationManager::Satellite6Credential"=>{},
         "ManageIQ::Providers::Awx::AutomationManager::VmwareCredential"=>{}},
       "ManageIQ::Providers::Awx::AutomationManager::MachineCredential"=>{},
       "ManageIQ::Providers::Awx::AutomationManager::NetworkCredential"=>{},
       "ManageIQ::Providers::Awx::AutomationManager::ScmCredential"=>{},
       "ManageIQ::Providers::Awx::AutomationManager::VaultCredential"=>{}}}},
 "ManageIQ::Providers::CloudManager::AuthKeyPair"=>
  {"ManageIQ::Providers::Amazon::CloudManager::AuthKeyPair"=>{},
   "ManageIQ::Providers::Google::CloudManager::AuthKeyPair"=>{},
   "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::AuthKeyPair"=>{},
   "ManageIQ::Providers::IbmCloud::VPC::CloudManager::AuthKeyPair"=>{},
   "ManageIQ::Providers::Openstack::CloudManager::AuthKeyPair"=>{"ManageIQ::Providers::IbmCic::CloudManager::AuthKeyPair"=>{}, "ManageIQ::Providers::IbmPowerVc::CloudManager::AuthKeyPair"=>{}}},
 "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow::ImageImportAuth"=>{},
 "ManageIQ::Providers::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow::SshPkeyAuth"=>{},
 "ManageIQ::Providers::IbmPowerVc::CloudManager::PvcImageImportWorkflow::ImageImportAuth"=>{},
 "ManageIQ::Providers::IbmPowerVc::CloudManager::PvcImageImportWorkflow::SshPkeyAuth"=>{}}
```

This also allows me to manipulate things for easier reading, for example:

```
> Authentication.hierarchy { |k| k.name.sub("ManageIQ::Providers::", "P::") }
=>
{"AuthPrivateKey"=>{"P::Openstack::InfraManager::AuthKeyPair"=>{}},
 "AuthToken"=>{},
 "AuthUseridPassword"=>{},
 "P::AutomationManager::Authentication"=>
  {"P::EmbeddedAutomationManager::Authentication"=>
    {"P::EmbeddedAnsible::AutomationManager::Credential"=>
      {"P::EmbeddedAnsible::AutomationManager::CloudCredential"=>
        {"P::EmbeddedAnsible::AutomationManager::AmazonCredential"=>{},
         "P::EmbeddedAnsible::AutomationManager::AzureCredential"=>{},
         "P::EmbeddedAnsible::AutomationManager::GoogleCredential"=>{},
         "P::EmbeddedAnsible::AutomationManager::OpenstackCredential"=>{},
         "P::EmbeddedAnsible::AutomationManager::RhvCredential"=>{},
         "P::EmbeddedAnsible::AutomationManager::VmwareCredential"=>{}},
       "P::EmbeddedAnsible::AutomationManager::MachineCredential"=>{},
       "P::EmbeddedAnsible::AutomationManager::NetworkCredential"=>{},
       "P::EmbeddedAnsible::AutomationManager::ScmCredential"=>{},
       "P::EmbeddedAnsible::AutomationManager::VaultCredential"=>{}},
     "P::Workflows::AutomationManager::Credential"=>{"P::Workflows::AutomationManager::ScmCredential"=>{}, "P::Workflows::AutomationManager::WorkflowCredential"=>{}}},
   "P::ExternalAutomationManager::Authentication"=>
    {"P::Awx::AutomationManager::Credential"=>
      {"P::AnsibleTower::AutomationManager::Credential"=>
        {"P::AnsibleTower::AutomationManager::CloudCredential"=>
          {"P::AnsibleTower::AutomationManager::AmazonCredential"=>{},
           "P::AnsibleTower::AutomationManager::AzureCredential"=>{},
           "P::AnsibleTower::AutomationManager::GoogleCredential"=>{},
           "P::AnsibleTower::AutomationManager::OpenstackCredential"=>{},
           "P::AnsibleTower::AutomationManager::RhvCredential"=>{},
           "P::AnsibleTower::AutomationManager::Satellite6Credential"=>{},
           "P::AnsibleTower::AutomationManager::VmwareCredential"=>{}},
         "P::AnsibleTower::AutomationManager::MachineCredential"=>{},
         "P::AnsibleTower::AutomationManager::NetworkCredential"=>{},
         "P::AnsibleTower::AutomationManager::ScmCredential"=>{},
         "P::AnsibleTower::AutomationManager::VaultCredential"=>{}},
       "P::Awx::AutomationManager::CloudCredential"=>
        {"P::Awx::AutomationManager::AmazonCredential"=>{},
         "P::Awx::AutomationManager::AzureCredential"=>{},
         "P::Awx::AutomationManager::GoogleCredential"=>{},
         "P::Awx::AutomationManager::OpenstackCredential"=>{},
         "P::Awx::AutomationManager::RhvCredential"=>{},
         "P::Awx::AutomationManager::Satellite6Credential"=>{},
         "P::Awx::AutomationManager::VmwareCredential"=>{}},
       "P::Awx::AutomationManager::MachineCredential"=>{},
       "P::Awx::AutomationManager::NetworkCredential"=>{},
       "P::Awx::AutomationManager::ScmCredential"=>{},
       "P::Awx::AutomationManager::VaultCredential"=>{}}}},
 "P::CloudManager::AuthKeyPair"=>
  {"P::Amazon::CloudManager::AuthKeyPair"=>{},
   "P::Google::CloudManager::AuthKeyPair"=>{},
   "P::IbmCloud::PowerVirtualServers::CloudManager::AuthKeyPair"=>{},
   "P::IbmCloud::VPC::CloudManager::AuthKeyPair"=>{},
   "P::Openstack::CloudManager::AuthKeyPair"=>{"P::IbmCic::CloudManager::AuthKeyPair"=>{}, "P::IbmPowerVc::CloudManager::AuthKeyPair"=>{}}},
 "P::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow::ImageImportAuth"=>{},
 "P::IbmCloud::PowerVirtualServers::CloudManager::ImageImportWorkflow::SshPkeyAuth"=>{},
 "P::IbmPowerVc::CloudManager::PvcImageImportWorkflow::ImageImportAuth"=>{},
 "P::IbmPowerVc::CloudManager::PvcImageImportWorkflow::SshPkeyAuth"=>{}}
```