### PR TITLE
fix sporadic thread_safety test failure

### DIFF
--- a/spec/core_ext/module/cache_with_timeout_spec.rb
+++ b/spec/core_ext/module/cache_with_timeout_spec.rb
@@ -163,7 +163,7 @@ describe Module do
       #   clears the current value, the other thread could get nil.
       test_class.cache_with_timeout(:thread_safety) { 2 }
 
-      Thread.new do
+      t = Thread.new do
         10000.times do
           test_class.thread_safety(true)
         end
@@ -172,6 +172,7 @@ describe Module do
       10000.times do
         expect(test_class.thread_safety).to eq(2)
       end
+      t.join
     end
   end
 end


### PR DESCRIPTION
For this test, the spawned thread was ending after the main block was running

When the main block quit, it undefined the method on the class. The threaded class kept calling the method (now undefined) and threw an exception because the method was no longer defined.

solution is to wait for the thread to finish before exiting and un-defining the method

fixes #77 