### PR TITLE
Fix issues where active_support does not require logger properly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,18 +9,38 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
-        - '2.5'
-        - '2.6'
         - '2.7'
         - '3.0'
         - '3.1'
         - '3.2'
         - '3.3'
-        - '3.2'
-        - '3.3'
+        rails-version:
+        - '6.0'
+        - '6.1'
+        - '7.0'
+        - '7.1'
+        include:
+        # Rails 7.0 and 7.1 support Ruby >= 2.7.0
+        - ruby-version: '2.5'
+          rails-version: '6.0'
+        - ruby-version: '2.5'
+          rails-version: '6.1'
+        - ruby-version: '2.6'
+          rails-version: '6.0'
+        - ruby-version: '2.6'
+          rails-version: '6.1'
+        # Rails 7.2 supports Ruby >= 3.1.0
+        - ruby-version: '3.1'
+          rails-version: '7.2'
+        - ruby-version: '3.2'
+          rails-version: '7.2'
+        - ruby-version: '3.3'
+          rails-version: '7.2'
     env:
+      TEST_RAILS_VERSION: "${{ matrix.rails-version }}"
       CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
     steps:
     - uses: actions/checkout@v4

--- a/Gemfile
+++ b/Gemfile
@@ -6,11 +6,20 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 # Specify your gem's dependencies in more_core_extensions.gemspec
 gemspec
 
-# Rails 5 dropped support for Ruby < 2.2.2
-# Rails 6 dropped support for Ruby < 2.4.4
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.2.2")
-  active_support_version = "< 5"
-elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.4")
-  active_support_version = "< 6"
-end
-gem 'activesupport', active_support_version
+minimum_version =
+  case ENV.fetch("TEST_RAILS_VERSION", "7.2")
+  when "7.2"
+    "~>7.2.2"
+  when "7.1"
+    "~>7.1.5"
+  when "7.0"
+    "~>7.0.8"
+  when "6.1"
+    "~>6.1.7"
+  when "6.0"
+    "~>6.0.6"
+  else
+    raise "Unexpected Rails version #{ENV['TEST_RAILS_VERSION'].inspect}"
+  end
+
+gem "activesupport", minimum_version

--- a/lib/more_core_extensions/core_ext/array/deletes.rb
+++ b/lib/more_core_extensions/core_ext/array/deletes.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_support'
 require 'active_support/core_ext/object/blank'
 

--- a/lib/more_core_extensions/core_ext/array/math.rb
+++ b/lib/more_core_extensions/core_ext/array/math.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_support'
 require 'active_support/core_ext/enumerable' # For Array#sum
 

--- a/lib/more_core_extensions/core_ext/class/hierarchy.rb
+++ b/lib/more_core_extensions/core_ext/class/hierarchy.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_support'
 require 'active_support/core_ext/class/subclasses'
 require 'active_support/core_ext/object/try'

--- a/lib/more_core_extensions/core_ext/digest/uuid.rb
+++ b/lib/more_core_extensions/core_ext/digest/uuid.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_support'
 require 'active_support/core_ext/digest/uuid'
 

--- a/lib/more_core_extensions/core_ext/hash/deletes.rb
+++ b/lib/more_core_extensions/core_ext/hash/deletes.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_support'
 require 'active_support/core_ext/object/blank'
 

--- a/lib/more_core_extensions/core_ext/object.rb
+++ b/lib/more_core_extensions/core_ext/object.rb
@@ -1,3 +1,4 @@
+require "logger" # Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264
 require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'more_core_extensions/core_ext/object/deep_send'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,3 +3,6 @@ SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "more_core_extensions/all"
+
+puts
+puts "\e[93mUsing ActiveSupport #{ActiveSupport.version}\e[0m"


### PR DESCRIPTION
Require logger due to active_support breaking on Rails <= 7.0. See https://github.com/rails/rails/pull/54264

Additionally, add testing of various activesupport versions