### PR TITLE
Add Ruby 3.4+, Rails 7.2+; Drop Ruby < 3.1, Rails < 7.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,31 +20,21 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-        - '2.7'
-        - '3.0'
         - '3.1'
         - '3.2'
         - '3.3'
+        - '3.4'
+        - '4.0'
+        - ruby-head
         rails-version:
-        - '6.0'
-        - '6.1'
-        - '7.0'
-        - '7.1'
-        include:
-        - ruby-version: '2.5'
-          rails-version: '6.0'
-        - ruby-version: '2.5'
-          rails-version: '6.1'
-        - ruby-version: '2.6'
-          rails-version: '6.0'
-        - ruby-version: '2.6'
-          rails-version: '6.1'
+        - '7.2'
+        - '8.0'
+        - '8.1'
+        exclude:
         - ruby-version: '3.1'
-          rails-version: '7.2'
-        - ruby-version: '3.2'
-          rails-version: '7.2'
-        - ruby-version: '3.3'
-          rails-version: '7.2'
+          rails-version: '8.1'
+        - ruby-version: '3.1'
+          rails-version: '8.0'
     env:
       TEST_RAILS_VERSION: "${{ matrix.rails-version }}"
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,11 @@ require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundle
 gemspec
 
 minimum_version =
-  case ENV.fetch("TEST_RAILS_VERSION", "7.2")
+  case ENV.fetch("TEST_RAILS_VERSION", "8.0")
+  when "8.1"
+    "~>8.1.2"
+  when "8.0"
+    "~>8.0.4"
   when "7.2"
     "~>7.2.2"
   when "7.1"
@@ -16,8 +20,6 @@ minimum_version =
     "~>7.0.8"
   when "6.1"
     "~>6.1.7"
-  when "6.0"
-    "~>6.0.6"
   else
     raise "Unexpected Rails version #{ENV['TEST_RAILS_VERSION'].inspect}"
   end

--- a/more_core_extensions.gemspec
+++ b/more_core_extensions.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.0.0"
 
   spec.add_runtime_dependency "activesupport"
+  spec.add_runtime_dependency "benchmark"
   spec.add_runtime_dependency "sync"
 
   spec.add_development_dependency "bundler"

--- a/spec/core_ext/string/to_i_with_method_spec.rb
+++ b/spec/core_ext/string/to_i_with_method_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe String do
   end
 
   it 'raises NoMethodError on private methods' do
-    expect { "1.raise".to_i_with_method }.to raise_error(NoMethodError, /private method `raise' called/)
+    expect { "1.raise".to_i_with_method }.to raise_error(NoMethodError, /private method [`']raise' called/)
   end
 end
 


### PR DESCRIPTION
I noticed clamp was failing on a completely unrelated PR in another repo on Rails 8.1, as saw the test matrix out of date. This PR updates it.