### PR TITLE
Fix literal . in email regex

### DIFF
--- a/lib/more_core_extensions/core_ext/string/formats.rb
+++ b/lib/more_core_extensions/core_ext/string/formats.rb
@@ -1,7 +1,7 @@
 module MoreCoreExtensions
   module StringFormats
     # From: http://www.regular-expressions.info/email.html
-    RE_EMAIL =  %r{\A[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z}i
+    RE_EMAIL = %r{\A[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\z}i
 
     def email?
       !!(self =~ RE_EMAIL)


### PR DESCRIPTION
These should have been literal `.`. When I checked with the source link it seems they updated it to fix it.