### PR TITLE
Add allowlist support to String#constantize and String#safe_constantize

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ MoreCoreExtensions are a set of core extensions beyond those provided by ActiveS
 
 #### String
 
+* core_ext/string/constantize_allowlist.rb
+  * `#constantize` - Enhanced version with optional `allowlist` parameter to restrict which constants can be resolved
+  * `#safe_constantize` - Enhanced version with optional `allowlist` parameter to restrict which constants can be resolved
 * core_ext/string/decimal_suffix.rb
   * `#decimal_si_to_big_decimal` - Returns a BigDecimal based on the number and suffix given
   * `#decimal_si_to_f` - Returns a Float based on the number and suffix given

--- a/lib/more_core_extensions/core_ext/string.rb
+++ b/lib/more_core_extensions/core_ext/string.rb
@@ -1,3 +1,4 @@
+require 'more_core_extensions/core_ext/string/constantize_allowlist'
 require 'more_core_extensions/core_ext/string/formats'
 require 'more_core_extensions/core_ext/string/hex_dump'
 require 'more_core_extensions/core_ext/string/iec60027_2'

--- a/lib/more_core_extensions/core_ext/string/constantize_allowlist.rb
+++ b/lib/more_core_extensions/core_ext/string/constantize_allowlist.rb
@@ -1,0 +1,28 @@
+require "active_support/core_ext/string/inflections"
+
+module MoreCoreExtensions
+  module StringConstantizeAllowlist
+    def self.allowed?(target, allowlist)
+      allowlist = allowlist.map { |o| o.respond_to?(:name) ? o.name : o }
+      allowlist.include?(target)
+    end
+
+    def constantize(allowlist: nil)
+      if allowlist && !StringConstantizeAllowlist.allowed?(self, allowlist)
+        raise NameError, "#{self} not found in allowlist"
+      end
+
+      super()
+    end
+
+    def safe_constantize(allowlist: nil)
+      if allowlist && !StringConstantizeAllowlist.allowed?(self, allowlist)
+        return nil
+      end
+
+      super()
+    end
+  end
+end
+
+String.send(:prepend, MoreCoreExtensions::StringConstantizeAllowlist)

--- a/spec/core_ext/string/constantize_allowlist_spec.rb
+++ b/spec/core_ext/string/constantize_allowlist_spec.rb
@@ -1,0 +1,181 @@
+describe String do
+  describe "#constantize" do
+    context "without allowlist" do
+      it "constantizes a valid constant" do
+        expect("String".constantize).to eq(String)
+        expect("Array".constantize).to eq(Array)
+        expect("Hash".constantize).to eq(Hash)
+      end
+
+      it "raises NameError for invalid constant" do
+        expect { "NonExistentClass".constantize }.to raise_error(NameError)
+      end
+    end
+
+    context "with allowlist as an Array of Strings" do
+      context "when the String is in the allowlist" do
+        it "constantizes the constant" do
+          expect("String".constantize(:allowlist => ["String"])).to eq(String)
+          expect("Array".constantize(:allowlist => ["String", "Array"])).to eq(Array)
+        end
+      end
+
+      context "when the String is not in the allowlist" do
+        it "raises NameError" do
+          expect { "String".constantize(:allowlist => ["Array"]) }.to raise_error(NameError, "String not found in allowlist")
+          expect { "Hash".constantize(:allowlist => ["String", "Array"]) }.to raise_error(NameError, "Hash not found in allowlist")
+        end
+      end
+    end
+
+    context "with allowlist as an Array of Classes" do
+      context "when the String is in the allowlist" do
+        it "constantizes the constant" do
+          expect("String".constantize(:allowlist => [String])).to eq(String)
+          expect("Array".constantize(:allowlist => [String, Array])).to eq(Array)
+        end
+      end
+
+      context "when the String is not in the allowlist" do
+        it "raises NameError" do
+          expect { "String".constantize(:allowlist => [Array]) }.to raise_error(NameError, "String not found in allowlist")
+          expect { "Hash".constantize(:allowlist => [String, Array]) }.to raise_error(NameError, "Hash not found in allowlist")
+        end
+      end
+    end
+
+    context "with mixed allowlist of Strings and Classes" do
+      it "handles mixed types correctly" do
+        expect("String".constantize(:allowlist => [String, "Array"])).to eq(String)
+        expect("Array".constantize(:allowlist => [String, "Array"])).to eq(Array)
+      end
+    end
+
+    context "with namespaced constants" do
+      context "without allowlist" do
+        it "constantizes namespaced constants" do
+          expect("Encoding::Converter".constantize).to eq(Encoding::Converter)
+          expect("Encoding::InvalidByteSequenceError".constantize).to eq(Encoding::InvalidByteSequenceError)
+        end
+      end
+
+      context "with allowlist as Strings" do
+        it "allows namespaced constants in allowlist" do
+          expect("Encoding::Converter".constantize(:allowlist => ["Encoding::Converter"])).to eq(Encoding::Converter)
+          expect("Encoding::InvalidByteSequenceError".constantize(:allowlist => ["Encoding::InvalidByteSequenceError"])).to eq(Encoding::InvalidByteSequenceError)
+        end
+
+        it "raises NameError when namespaced constant not in allowlist" do
+          expect { "Encoding::Converter".constantize(:allowlist => ["String"]) }.to raise_error(NameError, "Encoding::Converter not found in allowlist")
+        end
+      end
+
+      context "with allowlist as Classes" do
+        it "allows namespaced constants in allowlist" do
+          expect("Encoding::Converter".constantize(:allowlist => [Encoding::Converter])).to eq(Encoding::Converter)
+          expect("Encoding::InvalidByteSequenceError".constantize(:allowlist => [Encoding::InvalidByteSequenceError])).to eq(Encoding::InvalidByteSequenceError)
+        end
+
+        it "raises NameError when namespaced constant not in allowlist" do
+          expect { "Encoding::Converter".constantize(:allowlist => [String]) }.to raise_error(NameError, "Encoding::Converter not found in allowlist")
+        end
+      end
+    end
+  end
+
+  describe "#safe_constantize" do
+    context "without allowlist" do
+      it "constantizes a valid constant" do
+        expect("String".safe_constantize).to eq(String)
+        expect("Array".safe_constantize).to eq(Array)
+        expect("Hash".safe_constantize).to eq(Hash)
+      end
+
+      it "returns nil for invalid constant" do
+        expect("NonExistentClass".safe_constantize).to be_nil
+      end
+    end
+
+    context "with allowlist as an Array of Strings" do
+      context "when the String is in the allowlist" do
+        it "constantizes the constant" do
+          expect("String".safe_constantize(:allowlist => ["String"])).to eq(String)
+          expect("Array".safe_constantize(:allowlist => ["String", "Array"])).to eq(Array)
+        end
+      end
+
+      context "when the String is not in the allowlist" do
+        it "returns nil" do
+          expect("String".safe_constantize(:allowlist => ["Array"])).to be_nil
+          expect("Hash".safe_constantize(:allowlist => ["String", "Array"])).to be_nil
+        end
+      end
+    end
+
+    context "with allowlist as an Array of Classes" do
+      context "when the String is in the allowlist" do
+        it "constantizes the constant" do
+          expect("String".safe_constantize(:allowlist => [String])).to eq(String)
+          expect("Array".safe_constantize(:allowlist => [String, Array])).to eq(Array)
+        end
+      end
+
+      context "when the String is not in the allowlist" do
+        it "returns nil" do
+          expect("String".safe_constantize(:allowlist => [Array])).to be_nil
+          expect("Hash".safe_constantize(:allowlist => [String, Array])).to be_nil
+        end
+      end
+    end
+
+    context "with mixed allowlist of Strings and Classes" do
+      it "handles mixed types correctly" do
+        expect("String".safe_constantize(:allowlist => [String, "Array"])).to eq(String)
+        expect("Array".safe_constantize(:allowlist => [String, "Array"])).to eq(Array)
+      end
+    end
+
+    context "when constant does not exist" do
+      it "returns nil even with allowlist" do
+        expect("NonExistentClass".safe_constantize(:allowlist => ["NonExistentClass"])).to be_nil
+      end
+    end
+
+    context "with namespaced constants" do
+      context "without allowlist" do
+        it "constantizes namespaced constants" do
+          expect("Encoding::Converter".safe_constantize).to eq(Encoding::Converter)
+          expect("Encoding::InvalidByteSequenceError".safe_constantize).to eq(Encoding::InvalidByteSequenceError)
+        end
+      end
+
+      context "with allowlist as Strings" do
+        it "allows namespaced constants in allowlist" do
+          expect("Encoding::Converter".safe_constantize(:allowlist => ["Encoding::Converter"])).to eq(Encoding::Converter)
+          expect("Encoding::InvalidByteSequenceError".safe_constantize(:allowlist => ["Encoding::InvalidByteSequenceError"])).to eq(Encoding::InvalidByteSequenceError)
+        end
+
+        it "returns nil when namespaced constant not in allowlist" do
+          expect("Encoding::Converter".safe_constantize(:allowlist => ["String"])).to be_nil
+        end
+      end
+
+      context "with allowlist as Classes" do
+        it "allows namespaced constants in allowlist" do
+          expect("Encoding::Converter".safe_constantize(:allowlist => [Encoding::Converter])).to eq(Encoding::Converter)
+          expect("Encoding::InvalidByteSequenceError".safe_constantize(:allowlist => [Encoding::InvalidByteSequenceError])).to eq(Encoding::InvalidByteSequenceError)
+        end
+
+        it "returns nil when namespaced constant not in allowlist" do
+          expect("Encoding::Converter".safe_constantize(:allowlist => [String])).to be_nil
+        end
+      end
+
+      context "when namespaced constant does not exist" do
+        it "returns nil even with allowlist" do
+          expect("Encoding::NonExistent".safe_constantize(:allowlist => ["Encoding::NonExistent"])).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows usage of constantize in a "safer" way, particularly for user input, where you want to restrict to which classes constantize can resolve.

@agrare Please review.