### PR TITLE
Fix rubocop Lint/SendWithMixinArgument

### DIFF
--- a/lib/more_core_extensions/core_ext/array/compact_map.rb
+++ b/lib/more_core_extensions/core_ext/array/compact_map.rb
@@ -16,4 +16,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayCompactMap)
+Array.include MoreCoreExtensions::ArrayCompactMap

--- a/lib/more_core_extensions/core_ext/array/deletes.rb
+++ b/lib/more_core_extensions/core_ext/array/deletes.rb
@@ -29,4 +29,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayDeletes)
+Array.include MoreCoreExtensions::ArrayDeletes

--- a/lib/more_core_extensions/core_ext/array/duplicates.rb
+++ b/lib/more_core_extensions/core_ext/array/duplicates.rb
@@ -12,4 +12,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayDuplicates)
+Array.include MoreCoreExtensions::ArrayDuplicates

--- a/lib/more_core_extensions/core_ext/array/element_counts.rb
+++ b/lib/more_core_extensions/core_ext/array/element_counts.rb
@@ -15,4 +15,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayElementCounts)
+Array.include MoreCoreExtensions::ArrayElementCounts

--- a/lib/more_core_extensions/core_ext/array/inclusions.rb
+++ b/lib/more_core_extensions/core_ext/array/inclusions.rb
@@ -47,4 +47,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayInclusions)
+Array.include MoreCoreExtensions::ArrayInclusions

--- a/lib/more_core_extensions/core_ext/array/math.rb
+++ b/lib/more_core_extensions/core_ext/array/math.rb
@@ -34,4 +34,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayMath)
+Array.include MoreCoreExtensions::ArrayMath

--- a/lib/more_core_extensions/core_ext/array/nested.rb
+++ b/lib/more_core_extensions/core_ext/array/nested.rb
@@ -15,4 +15,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayNested)
+Array.include MoreCoreExtensions::ArrayNested

--- a/lib/more_core_extensions/core_ext/array/random.rb
+++ b/lib/more_core_extensions/core_ext/array/random.rb
@@ -22,4 +22,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayRandom)
+Array.include MoreCoreExtensions::ArrayRandom

--- a/lib/more_core_extensions/core_ext/array/sorting.rb
+++ b/lib/more_core_extensions/core_ext/array/sorting.rb
@@ -54,4 +54,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::StableSorting)
+Array.include MoreCoreExtensions::StableSorting

--- a/lib/more_core_extensions/core_ext/array/stretch.rb
+++ b/lib/more_core_extensions/core_ext/array/stretch.rb
@@ -47,5 +47,5 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:extend, MoreCoreExtensions::ArrayStretch::ClassMethods)
-Array.send(:include, MoreCoreExtensions::ArrayStretch)
+Array.extend MoreCoreExtensions::ArrayStretch::ClassMethods
+Array.include MoreCoreExtensions::ArrayStretch

--- a/lib/more_core_extensions/core_ext/array/tableize.rb
+++ b/lib/more_core_extensions/core_ext/array/tableize.rb
@@ -168,4 +168,4 @@ module MoreCoreExtensions
   end
 end
 
-Array.send(:include, MoreCoreExtensions::ArrayTableize)
+Array.include MoreCoreExtensions::ArrayTableize

--- a/lib/more_core_extensions/core_ext/benchmark/realtime_store.rb
+++ b/lib/more_core_extensions/core_ext/benchmark/realtime_store.rb
@@ -104,4 +104,4 @@ module MoreCoreExtensions
   end
 end
 
-Benchmark.send(:extend, MoreCoreExtensions::BenchmarkRealtimeStore)
+Benchmark.extend MoreCoreExtensions::BenchmarkRealtimeStore

--- a/lib/more_core_extensions/core_ext/class/hierarchy.rb
+++ b/lib/more_core_extensions/core_ext/class/hierarchy.rb
@@ -66,4 +66,4 @@ module MoreCoreExtensions
   end
 end
 
-Class.send(:include, MoreCoreExtensions::ClassHierarchy)
+Class.include MoreCoreExtensions::ClassHierarchy

--- a/lib/more_core_extensions/core_ext/hash/deletes.rb
+++ b/lib/more_core_extensions/core_ext/hash/deletes.rb
@@ -30,4 +30,4 @@ module MoreCoreExtensions
   end
 end
 
-Hash.send(:include, MoreCoreExtensions::HashDeletes)
+Hash.include MoreCoreExtensions::HashDeletes

--- a/lib/more_core_extensions/core_ext/hash/nested.rb
+++ b/lib/more_core_extensions/core_ext/hash/nested.rb
@@ -15,4 +15,4 @@ module MoreCoreExtensions
   end
 end
 
-Hash.send(:include, MoreCoreExtensions::HashNested)
+Hash.include MoreCoreExtensions::HashNested

--- a/lib/more_core_extensions/core_ext/hash/sorting.rb
+++ b/lib/more_core_extensions/core_ext/hash/sorting.rb
@@ -16,5 +16,5 @@ module MoreCoreExtensions
   end
 end
 
-Hash.send(:include, MoreCoreExtensions::HashSortBang) unless Hash.method_defined?(:sort!)
-Hash.send(:include, MoreCoreExtensions::HashSortByBang) unless Hash.method_defined?(:sort_by!)
+Hash.include MoreCoreExtensions::HashSortBang unless Hash.method_defined?(:sort!)
+Hash.include MoreCoreExtensions::HashSortByBang unless Hash.method_defined?(:sort_by!)

--- a/lib/more_core_extensions/core_ext/math/slope.rb
+++ b/lib/more_core_extensions/core_ext/math/slope.rb
@@ -51,4 +51,4 @@ module MoreCoreExtensions
   end
 end
 
-Math.send(:extend, MoreCoreExtensions::MathSlope::ClassMethods)
+Math.extend MoreCoreExtensions::MathSlope::ClassMethods

--- a/lib/more_core_extensions/core_ext/module/cache_with_timeout.rb
+++ b/lib/more_core_extensions/core_ext/module/cache_with_timeout.rb
@@ -97,5 +97,5 @@ module MoreCoreExtensions
   end
 end
 
-Module.send(:include, MoreCoreExtensions::CacheWithTimeout)
-Module.send(:extend, MoreCoreExtensions::CacheWithTimeout::ClassMethods)
+Module.include MoreCoreExtensions::CacheWithTimeout
+Module.extend MoreCoreExtensions::CacheWithTimeout::ClassMethods

--- a/lib/more_core_extensions/core_ext/module/namespace.rb
+++ b/lib/more_core_extensions/core_ext/module/namespace.rb
@@ -10,4 +10,4 @@ module MoreCoreExtensions
   end
 end
 
-Module.send(:include, MoreCoreExtensions::ModuleNamespace)
+Module.include MoreCoreExtensions::ModuleNamespace

--- a/lib/more_core_extensions/core_ext/numeric/clamp.rb
+++ b/lib/more_core_extensions/core_ext/numeric/clamp.rb
@@ -15,4 +15,4 @@ module MoreCoreExtensions
   end
 end
 
-Numeric.send(:prepend, MoreCoreExtensions::NumericClamp)
+Numeric.prepend MoreCoreExtensions::NumericClamp

--- a/lib/more_core_extensions/core_ext/numeric/math.rb
+++ b/lib/more_core_extensions/core_ext/numeric/math.rb
@@ -11,4 +11,4 @@ module MoreCoreExtensions
   end
 end
 
-Numeric.send(:prepend, MoreCoreExtensions::NumericMath)
+Numeric.prepend MoreCoreExtensions::NumericMath

--- a/lib/more_core_extensions/core_ext/numeric/rounding.rb
+++ b/lib/more_core_extensions/core_ext/numeric/rounding.rb
@@ -14,4 +14,4 @@ module MoreCoreExtensions
   end
 end
 
-Numeric.send(:prepend, MoreCoreExtensions::NumericRounding)
+Numeric.prepend MoreCoreExtensions::NumericRounding

--- a/lib/more_core_extensions/core_ext/object/deep_send.rb
+++ b/lib/more_core_extensions/core_ext/object/deep_send.rb
@@ -25,4 +25,4 @@ module MoreCoreExtensions
   end
 end
 
-Object.send(:include, MoreCoreExtensions::ObjectDeepSend)
+Object.include MoreCoreExtensions::ObjectDeepSend

--- a/lib/more_core_extensions/core_ext/object/namespace.rb
+++ b/lib/more_core_extensions/core_ext/object/namespace.rb
@@ -16,4 +16,4 @@ module MoreCoreExtensions
   end
 end
 
-Object.send(:include, MoreCoreExtensions::ObjectNamespace)
+Object.include MoreCoreExtensions::ObjectNamespace

--- a/lib/more_core_extensions/core_ext/process/pause_resume.rb
+++ b/lib/more_core_extensions/core_ext/process/pause_resume.rb
@@ -107,4 +107,4 @@ module MoreCoreExtensions
   end
 end
 
-Process.send(:extend, MoreCoreExtensions::ProcessPauseResume)
+Process.extend MoreCoreExtensions::ProcessPauseResume

--- a/lib/more_core_extensions/core_ext/range/step_value.rb
+++ b/lib/more_core_extensions/core_ext/range/step_value.rb
@@ -42,4 +42,4 @@ module MoreCoreExtensions
   end
 end
 
-Range.send(:include, MoreCoreExtensions::RangeStepValue)
+Range.include MoreCoreExtensions::RangeStepValue

--- a/lib/more_core_extensions/core_ext/string/constantize_allowlist.rb
+++ b/lib/more_core_extensions/core_ext/string/constantize_allowlist.rb
@@ -25,4 +25,4 @@ module MoreCoreExtensions
   end
 end
 
-String.send(:prepend, MoreCoreExtensions::StringConstantizeAllowlist)
+String.prepend MoreCoreExtensions::StringConstantizeAllowlist

--- a/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
+++ b/lib/more_core_extensions/core_ext/string/decimal_suffix.rb
@@ -27,4 +27,4 @@ module MoreCoreExtensions
   end
 end
 
-String.send(:prepend, MoreCoreExtensions::DecimalSI)
+String.prepend MoreCoreExtensions::DecimalSI

--- a/lib/more_core_extensions/core_ext/string/formats.rb
+++ b/lib/more_core_extensions/core_ext/string/formats.rb
@@ -47,4 +47,4 @@ module MoreCoreExtensions
   end
 end
 
-String.send(:include, MoreCoreExtensions::StringFormats)
+String.include MoreCoreExtensions::StringFormats

--- a/lib/more_core_extensions/core_ext/string/hex_dump.rb
+++ b/lib/more_core_extensions/core_ext/string/hex_dump.rb
@@ -66,4 +66,4 @@ module MoreCoreExtensions
   end
 end
 
-String.send(:include, MoreCoreExtensions::StringHexDump)
+String.include MoreCoreExtensions::StringHexDump

--- a/lib/more_core_extensions/core_ext/string/iec60027_2.rb
+++ b/lib/more_core_extensions/core_ext/string/iec60027_2.rb
@@ -18,4 +18,4 @@ module MoreCoreExtensions
   end
 end
 
-String.send(:prepend, MoreCoreExtensions::IEC60027_2)
+String.prepend MoreCoreExtensions::IEC60027_2

--- a/lib/more_core_extensions/core_ext/string/to_i_with_method.rb
+++ b/lib/more_core_extensions/core_ext/string/to_i_with_method.rb
@@ -81,7 +81,7 @@ module MoreCoreExtensions
   end
 end
 
-String.send(:prepend, MoreCoreExtensions::StringToIWithMethod)
-Numeric.send(:prepend, MoreCoreExtensions::NumericAndNilToIWithMethod)
-NilClass.send(:prepend, MoreCoreExtensions::NumericAndNilToIWithMethod)
-Object.send(:prepend, MoreCoreExtensions::ObjectToIWithMethod)
+String.prepend MoreCoreExtensions::StringToIWithMethod
+Numeric.prepend MoreCoreExtensions::NumericAndNilToIWithMethod
+NilClass.prepend MoreCoreExtensions::NumericAndNilToIWithMethod
+Object.prepend MoreCoreExtensions::ObjectToIWithMethod

--- a/lib/more_core_extensions/core_ext/symbol/to_i.rb
+++ b/lib/more_core_extensions/core_ext/symbol/to_i.rb
@@ -6,4 +6,4 @@ module MoreCoreExtensions
   end
 end
 
-Symbol.send(:include, MoreCoreExtensions::SymbolToI) unless Symbol.method_defined?(:to_i)
+Symbol.include MoreCoreExtensions::SymbolToI unless Symbol.method_defined?(:to_i)


### PR DESCRIPTION
> include and prepend methods were private methods until Ruby 2.0, they
> were mixed-in via send method. This cop uses Ruby 2.1 or higher style
> that can be called by public methods. And extend method that was
> originally a public method is also targeted for style unification.

@agrare Please review. I did this with `rubocop --only Lint/SendWithMixinArgument -a`